### PR TITLE
Remove dist directory before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
-    "build": "tsc && copyfiles --all 'generators/*/templates/**/*' dist && cp package.json dist/",
+    "build": "rm -fr dist && tsc && copyfiles --all 'generators/*/templates/**/*' dist && cp package.json dist/",
     "lint": "eslint --ext ts generators utils"
   }
 }


### PR DESCRIPTION
Remove directory before build to let file removals be respected in dist directory.