### PR TITLE
Exclude node_modules when copying templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "yeoman-test": "^3.0.0"
   },
   "scripts": {
-    "build": "rm -fr dist && tsc && copyfiles --all 'generators/*/templates/**/*' dist && cp package.json dist/",
+    "build": "rm -fr dist && tsc && copyfiles --all --exclude '**/node_modules/**' 'generators/*/templates/**/*' dist && cp package.json dist/",
     "lint": "eslint --ext ts generators utils",
     "test": "yarn test:utils && yarn test:generators",
     "test:generators": "jest --runInBand --testTimeout 60000 generators",


### PR DESCRIPTION
This allows installing dependencies in templates folders to test things.