### PR TITLE
Rename name option into packageName

### DIFF
--- a/generators/create-react-app/index.ts
+++ b/generators/create-react-app/index.ts
@@ -1,28 +1,22 @@
-import Generator, { GeneratorOptions } from 'yeoman-generator';
+import PackageGenerator from '../../utils/PackageGenerator';
 
-class CreateReactAppGenerator extends Generator {
-    constructor(args: string | string[], opts: GeneratorOptions) {
-        super(args, opts);
-
-        this.argument('name', { type: String, required: true });
-    }
-
+class CreateReactAppGenerator extends PackageGenerator {
     writing(): void {
-        const { name } = this.options;
+        const { packageName } = this.options;
 
         this.fs.copyTpl(
             this.templatePath('base'),
-            this.destinationPath(name),
-            { name },
+            this.destinationPath(packageName),
+            { packageName },
             undefined,
             { globOptions: { dot: true } },
         );
     }
 
     install(): void {
-        const { name } = this.options;
+        const { packageName } = this.options;
 
-        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(name) });
+        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
     }
 }
 

--- a/generators/create-react-app/templates/base/package.json.ejs
+++ b/generators/create-react-app/templates/base/package.json.ejs
@@ -1,5 +1,5 @@
 {
-  "name": "<%= name %>",
+  "name": "<%= packageName %>",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/generators/express/templates/ansible/deployment.yaml.ejs
+++ b/generators/express/templates/ansible/deployment.yaml.ejs
@@ -6,14 +6,14 @@
     - import_role:
         name: deploy
       vars:
-        path: /home/<%= name %>
-        artifact: <%= name %>.tar.gz
-        environment: '{{ <%= name.replace('-', '_') %>.env }}'
+        path: /home/<%= packageName %>
+        artifact: <%= packageName %>.tar.gz
+        environment: '{{ <%= packageName.replace('-', '_') %>.env }}'
   vars:
-    job_name: <%= name %>-archive
+    job_name: <%= packageName %>-archive
     repository_name: <%= repositoryName %>
   vars_files:
     - vars/circleci.yaml
     - vars/github.yaml
   tags:
-    - <%= name %>
+    - <%= packageName %>

--- a/generators/express/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/all.yaml.ejs
@@ -1,6 +1,6 @@
-<%= name.replace('-', '_') %>:
+<%= packageName.replace('-', '_') %>:
   env:
-    DATABASE_URL: postgres://<%= name %>:{{ <%= name.replace('-', '_') %>.database_password }}@localhost/<%= name %>
+    DATABASE_URL: postgres://<%= packageName %>:{{ <%= packageName.replace('-', '_') %>.database_password }}@localhost/<%= packageName %>
     NODE_ENV: production
     SENTRY_DSN: ~ # Add your sentry DSN here
     SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/express/templates/ansible/group_vars/staging.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/staging.yaml.ejs
@@ -1,4 +1,4 @@
-<%= name.replace('-', '_') %>:
+<%= packageName.replace('-', '_') %>:
   database_password: !vault |
 <%= indent(databasePassword, 4) %>
   domain: <%= domain %>

--- a/generators/express/templates/ansible/provision.yaml.ejs
+++ b/generators/express/templates/ansible/provision.yaml.ejs
@@ -4,48 +4,48 @@
         name: postgresql
       vars:
         dbs:
-          <%= name %>:
-            owner: <%= name %>
+          <%= packageName %>:
+            owner: <%= packageName %>
         users:
-          <%= name %>:
-            password: '{{ <%= name.replace('-', '_') %>.database_password }}'
+          <%= packageName %>:
+            password: '{{ <%= packageName.replace('-', '_') %>.database_password }}'
     - import_role:
         name: nodejs
       vars:
         version: 14
     - group:
-        name: <%= name %>
+        name: <%= packageName %>
         state: present
     - user:
-        name: <%= name %>
+        name: <%= packageName %>
         state: present
-        group: <%= name %>
+        group: <%= packageName %>
     - import_role:
         name: envfile
       vars:
-        path: /home/<%= name %>/env
-        env: '{{ <%= name %>.env }}'
+        path: /home/<%= packageName %>/env
+        env: '{{ <%= packageName %>.env }}'
     - name: Configure env
       lineinfile:
-        path: /home/<%= name %>/.bashrc
-        line: set -a; source /home/<%= name %>/env; set +a
+        path: /home/<%= packageName %>/.bashrc
+        line: set -a; source /home/<%= packageName %>/env; set +a
     - import_role:
         name: service
       vars:
-        command: /usr/bin/node /home/<%= name %>/current/dist
-        description: <%= name %>
-        service: <%= name %>
-        user: <%= name %>
-        group: <%= name %>
-        env: '{{ <%= name.replace('-', '_') %>.env }}'
+        command: /usr/bin/node /home/<%= packageName %>/current/dist
+        description: <%= packageName %>
+        service: <%= packageName %>
+        user: <%= packageName %>
+        group: <%= packageName %>
+        env: '{{ <%= packageName.replace('-', '_') %>.env }}'
     - import_role:
         name: site
       vars:
         email: '{{ contact_email }}'
-        site: <%= name %>
-        domain: '{{ <%= name.replace('-', '_') %>.domain }}'
+        site: <%= packageName %>
+        domain: '{{ <%= packageName.replace('-', '_') %>.domain }}'
         config: |
-          root /home/<%= name %>/current/dist;
+          root /home/<%= packageName %>/current/dist;
 
           client_max_body_size 25M;
 
@@ -57,4 +57,4 @@
               proxy_set_header X-Forwarded-Proto $scheme;
           }
   tags:
-    - <%= name %>
+    - <%= packageName %>

--- a/generators/express/templates/base/docker/Dockerfile.ejs
+++ b/generators/express/templates/base/docker/Dockerfile.ejs
@@ -6,8 +6,8 @@ ARG UID=1000
 RUN useradd --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= name %>
+WORKDIR /usr/src/project/<%= packageName %>
 
-ENV PATH="/usr/src/project/<%= name %>/node_modules/.bin:${PATH}"
+ENV PATH="/usr/src/project/<%= packageName %>/node_modules/.bin:${PATH}"
 
 CMD ["yarn", "start"]

--- a/generators/express/templates/base/package.json.ejs
+++ b/generators/express/templates/base/package.json.ejs
@@ -1,5 +1,5 @@
 {
-  "name": "<%= name %>",
+  "name": "<%= packageName %>",
   "dependencies": {
     "@sentry/node": "^5.29.2",
     "express": "^5.0.0-alpha.8",

--- a/generators/express/templates/base/src/index.ts.ejs
+++ b/generators/express/templates/base/src/index.ts.ejs
@@ -5,7 +5,7 @@ import version from './version';
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENVIRONMENT,
-    release: version ? `<%= projectName %>-<%= name %>@${version}` : undefined,
+    release: version ? `<%= projectName %>-<%= packageName %>@${version}` : undefined,
 });
 
 const port: number = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;

--- a/generators/express/templates/circleci.yaml.ejs
+++ b/generators/express/templates/circleci.yaml.ejs
@@ -1,8 +1,8 @@
 jobs:
-  <%= name %>-yarn-install:
+  <%= packageName %>-yarn-install:
     docker:
       - image: circleci/node:14.15.1
-    working_directory: ~/project/<%= name %>
+    working_directory: ~/project/<%= packageName %>
     steps:
       - checkout:
           path: ~/project
@@ -22,12 +22,12 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-              - <%= name %>/node_modules
+              - <%= packageName %>/node_modules
 
-  <%= name %>-lint:
+  <%= packageName %>-lint:
     docker:
       - image: circleci/node:14.15.1
-    working_directory: ~/project/<%= name %>
+    working_directory: ~/project/<%= packageName %>
     steps:
       - checkout:
           path: ~/project
@@ -36,10 +36,10 @@ jobs:
       - run:
           command: yarn lint
 
-  <%= name %>-build:
+  <%= packageName %>-build:
     docker:
       - image: circleci/node:14.15.1
-    working_directory: ~/project/<%= name %>
+    working_directory: ~/project/<%= packageName %>
     steps:
       - checkout:
           path: ~/project
@@ -53,12 +53,12 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-              - <%= name %>/dist
+              - <%= packageName %>/dist
 
-  <%= name %>-archive:
+  <%= packageName %>-archive:
     docker:
       - image: circleci/node:14.15.1
-    working_directory: ~/project/<%= name %>
+    working_directory: ~/project/<%= packageName %>
     steps:
       - checkout:
           path: ~/project
@@ -74,39 +74,39 @@ jobs:
               node_modules/ \
       - store_artifacts:
           path: archive.tar.gz
-          destination: <%= name %>.tar.gz
+          destination: <%= packageName %>.tar.gz
 
-  <%= name %>-sentry-release:
+  <%= packageName %>-sentry-release:
     docker:
       - image: getsentry/sentry-cli:1.61.0
         entrypoint: ''
         environment:
-          SENTRY_PROJECT: <%= projectName %>-<%= name %>
+          SENTRY_PROJECT: <%= projectName %>-<%= packageName %>
     steps:
       - attach_workspace:
           at: ~/project
-      - run: sentry-cli releases new <%= projectName %>-<%= name %>@${CIRCLE_SHA1}
-      - run: sentry-cli releases files <%= projectName %>-<%= name %>@${CIRCLE_SHA1} upload-sourcemaps <%= name %>/dist
-      - run: sentry-cli releases finalize <%= projectName %>-<%= name %>@${CIRCLE_SHA1}
+      - run: sentry-cli releases new <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
+      - run: sentry-cli releases files <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1} upload-sourcemaps <%= packageName %>/dist
+      - run: sentry-cli releases finalize <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
 
 workflows:
   version: '2'
   build:
     jobs:
-      - <%= name %>-yarn-install
-      - <%= name %>-lint:
+      - <%= packageName %>-yarn-install
+      - <%= packageName %>-lint:
           requires:
-            - <%= name %>-yarn-install
-      - <%= name %>-build:
+            - <%= packageName %>-yarn-install
+      - <%= packageName %>-build:
           requires:
-            - <%= name %>-lint
-      - <%= name %>-archive:
+            - <%= packageName %>-lint
+      - <%= packageName %>-archive:
           requires:
-            - <%= name %>-build
-      - <%= name %>-sentry-release:
+            - <%= packageName %>-build
+      - <%= packageName %>-sentry-release:
           context: sentry
           requires:
-            - <%= name %>-build
+            - <%= packageName %>-build
           filters:
             branches:
               only:

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -1,7 +1,7 @@
 services:
-    <%= name %>:
-        build: <%= name %>/docker
+    <%= packageName %>:
+        build: <%= packageName %>/docker
         volumes:
-            - ./<%= name %>:/usr/src/project/<%= name %>
+            - ./<%= packageName %>:/usr/src/project/<%= packageName %>
         ports:
             - 3000:3000

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -1,23 +1,17 @@
-import Generator, { GeneratorOptions } from 'yeoman-generator';
+import PackageGenerator from '../../utils/PackageGenerator';
 
-class NextJSGenerator extends Generator {
-    constructor(args: string | string[], opts: GeneratorOptions) {
-        super(args, opts);
-
-        this.argument('name', { type: String, required: true });
-    }
-
+class NextJSGenerator extends PackageGenerator {
     writing() {
-        const { name } = this.options;
-        this.fs.copyTpl(this.templatePath('base'), this.destinationPath(name), {
-            name,
+        const { packageName } = this.options;
+        this.fs.copyTpl(this.templatePath('base'), this.destinationPath(packageName), {
+            packageName,
         });
     }
 
     install(): void {
-        const { name } = this.options;
+        const { packageName } = this.options;
 
-        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(name) });
+        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
     }
 }
 

--- a/generators/next-js/templates/base/package.json
+++ b/generators/next-js/templates/base/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= name %>",
+  "name": "<%= packageName %>",
   "dependencies": {
     "next": "^10.0.6",
     "react": "^17.0.1",

--- a/utils/PackageGenerator.ts
+++ b/utils/PackageGenerator.ts
@@ -1,10 +1,24 @@
 import ejs, { Data } from 'ejs';
 import YAML, { Options } from 'yaml';
-import Generator from 'yeoman-generator';
+import Generator, { GeneratorOptions } from 'yeoman-generator';
 import { Config, mergeConfig } from './circleci';
 import indent from './indent';
 
-class BaseGenerator extends Generator {
+interface PackageGeneratorOption extends GeneratorOptions {
+    packageName: string;
+}
+
+class PackageGenerator extends Generator<PackageGeneratorOption> {
+    constructor(args: string | string[], opts: PackageGeneratorOption) {
+        super(args, opts);
+
+        this.argument('packageName', { type: String, required: true });
+
+        if (!/^[a-z0-9-]+$/.test(this.options.name)) {
+            throw new Error('Package name can only contains lowercase numbers, numbers and dashes');
+        }
+    }
+
     async configureDockerCompose(templatePath: string, context: Data) {
         await this.extendYAML(
             templatePath,
@@ -64,4 +78,4 @@ class BaseGenerator extends Generator {
     }
 }
 
-export default BaseGenerator;
+export default PackageGenerator;


### PR DESCRIPTION
The name option was ambiguous between the project name, and the package name. This clears the comfusion by renaming the option to packageName.

Additionally, this factorise part of the logic into the base PackageGenerator class.