### PR TITLE
Move generator tests outside of `__tests__` folders

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,15 @@
     "parserOptions": {
         "project": "./tsconfig.json"
     },
+    "rules": {
+        "import/no-extraneous-dependencies": ["error", {
+           "devDependencies": [
+                "**/__tests__/**",
+                "**/*.test.ts"
+            ],
+            "optionalDependencies": false
+        }]
+    },
     "overrides": [
         {
             "files": ["**/__tests__/*.ts", "*.test.ts"],

--- a/generators/app/index.test.ts
+++ b/generators/app/index.test.ts
@@ -6,7 +6,7 @@ describe('When running the generator with Create React App', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '..'))
+        const result = await helpers.run(__dirname)
             .withPrompts({ backend: 'express', contactEmail: 'test@example.com', frontend: 'create-react-app' });
 
         root = result.cwd;
@@ -33,7 +33,7 @@ describe('When running the generator with Next.js', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '..'))
+        const result = await helpers.run(__dirname)
             .withPrompts({ backend: 'express', contactEmail: 'test@example.com', frontend: 'next-js' });
 
         root = result.cwd;

--- a/generators/create-react-app/index.test.ts
+++ b/generators/create-react-app/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import execa from 'execa';
-import { omit } from 'ramda';
 import YAML from 'yaml';
 import helpers from 'yeoman-test';
 
@@ -9,14 +8,14 @@ describe('When running the generator', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '../../root'))
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
             .withPrompts({ contactEmail: 'test@example.com' });
 
         root = result.cwd;
 
-        await helpers.run(path.resolve(__dirname, '..'))
+        await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false, twig: true })
+            .withOptions({ skipInstall: false })
             .withArguments(['test']);
     });
 
@@ -25,19 +24,11 @@ describe('When running the generator', () => {
     });
 
     test('It generates a project which correctly builds', async () => {
-        await execa('yarn', ['build'], {
-            cwd: path.resolve(root, 'test'),
-            env: omit(['NODE_ENV'], process.env),
-            extendEnv: false,
-        });
+        await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
     });
 
     test('It generates a project which correctly lints', async () => {
-        const cwd = path.resolve(root, 'test');
-
-        await execa('vendor/bin/php-cs-fixer', ['fix', '--dry-run', '--diff', '--using-cache', 'no'], { cwd });
-        await execa('yarn', ['lint:js'], { cwd });
-        await execa('yarn', ['lint:scss'], { cwd });
+        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
     });
 
     test('It generates a docker-compose.yaml with a version fields', async () => {
@@ -49,6 +40,6 @@ describe('When running the generator', () => {
     test('It extends the ansible configuration', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'ansible/group_vars/all.yaml'), 'utf8'));
 
-        expect(all.test_env).toBeDefined();
+        expect(all.test_data).toBeDefined();
     });
 });

--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -8,12 +8,12 @@ describe('When running the generator', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '../../root'))
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
             .withPrompts({ contactEmail: 'test@example.com' });
 
         root = result.cwd;
 
-        await helpers.run(path.resolve(__dirname, '..'))
+        await helpers.run(__dirname)
             .cd(root)
             .withOptions({ skipInstall: false })
             .withArguments(['test']);
@@ -27,9 +27,19 @@ describe('When running the generator', () => {
         await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
     });
 
+    test('It generates a project which correctly lints', async () => {
+        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
+    });
+
     test('It generates a docker-compose.yaml with a version fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
 
         expect(all.version).toBeDefined();
+    });
+
+    test('It extends the ansible configuration', async () => {
+        const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'ansible/group_vars/all.yaml'), 'utf8'));
+
+        expect(all.test_env).toBeDefined();
     });
 });

--- a/generators/next-js/index.test.ts
+++ b/generators/next-js/index.test.ts
@@ -8,12 +8,12 @@ describe('When running the generator', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '../../root'))
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
             .withPrompts({ contactEmail: 'test@example.com' });
 
         root = result.cwd;
 
-        await helpers.run(path.resolve(__dirname, '..'))
+        await helpers.run(__dirname)
             .cd(root)
             .withOptions({ skipInstall: false })
             .withArguments(['test']);
@@ -27,19 +27,9 @@ describe('When running the generator', () => {
         await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
     });
 
-    test('It generates a project which correctly lints', async () => {
-        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
-    });
-
     test('It generates a docker-compose.yaml with a version fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
 
         expect(all.version).toBeDefined();
-    });
-
-    test('It extends the ansible configuration', async () => {
-        const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'ansible/group_vars/all.yaml'), 'utf8'));
-
-        expect(all.test_env).toBeDefined();
     });
 });

--- a/generators/root/index.test.ts
+++ b/generators/root/index.test.ts
@@ -6,7 +6,7 @@ describe('When running the generator', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '..'))
+        const result = await helpers.run(__dirname)
             .withPrompts({ contactEmail: 'test@example.com' });
 
         root = result.cwd;

--- a/generators/symfony/index.test.ts
+++ b/generators/symfony/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import execa from 'execa';
+import { omit } from 'ramda';
 import YAML from 'yaml';
 import helpers from 'yeoman-test';
 
@@ -8,14 +9,14 @@ describe('When running the generator', () => {
     let root: string;
 
     beforeAll(async () => {
-        const result = await helpers.run(path.resolve(__dirname, '../../root'))
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
             .withPrompts({ contactEmail: 'test@example.com' });
 
         root = result.cwd;
 
-        await helpers.run(path.resolve(__dirname, '..'))
+        await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false })
+            .withOptions({ skipInstall: false, twig: true })
             .withArguments(['test']);
     });
 
@@ -24,11 +25,19 @@ describe('When running the generator', () => {
     });
 
     test('It generates a project which correctly builds', async () => {
-        await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
+        await execa('yarn', ['build'], {
+            cwd: path.resolve(root, 'test'),
+            env: omit(['NODE_ENV'], process.env),
+            extendEnv: false,
+        });
     });
 
     test('It generates a project which correctly lints', async () => {
-        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
+        const cwd = path.resolve(root, 'test');
+
+        await execa('vendor/bin/php-cs-fixer', ['fix', '--dry-run', '--diff', '--using-cache', 'no'], { cwd });
+        await execa('yarn', ['lint:js'], { cwd });
+        await execa('yarn', ['lint:scss'], { cwd });
     });
 
     test('It generates a docker-compose.yaml with a version fields', async () => {
@@ -40,6 +49,6 @@ describe('When running the generator', () => {
     test('It extends the ansible configuration', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'ansible/group_vars/all.yaml'), 'utf8'));
 
-        expect(all.test_data).toBeDefined();
+        expect(all.test_env).toBeDefined();
     });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "exclude": [
         "generators/*/templates",
-        "**/__tests__"
+        "**/__tests__",
+        "**/*.test.ts"
     ]
 }


### PR DESCRIPTION
No need to have a separate folder to hold an unique file.