### PR TITLE
Fix prompt default values when running in a folder with dashes

### DIFF
--- a/generators/create-react-app/index.ts
+++ b/generators/create-react-app/index.ts
@@ -9,13 +9,14 @@ class CreateReactAppGenerator extends PackageGenerator {
 
     async prompting() {
         const { packageName } = this.options;
+        const projectName = this.config.get('projectName');
 
         this.#answers = await this.prompt([
             {
                 type: 'input',
                 name: 'domain',
                 message: `The domain for ${packageName}`,
-                default: `${packageName}.${this.appname}.thetribe.io`,
+                default: `${packageName}.${projectName}.thetribe.io`,
             },
         ]);
     }

--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -10,13 +10,14 @@ class ExpressGenerator extends PackageGenerator {
 
     async prompting() {
         const { packageName } = this.options;
+        const projectName = this.config.get('projectName');
 
         this.#answers = await this.prompt([
             {
                 type: 'input',
                 name: 'domain',
                 message: `The domain for ${packageName}`,
-                default: `${packageName}.${this.appname}.thetribe.io`,
+                default: `${packageName}.${projectName}.thetribe.io`,
             },
         ]);
     }

--- a/generators/root/index.ts
+++ b/generators/root/index.ts
@@ -18,7 +18,7 @@ class RootGenerator extends Generator {
                 type: 'input',
                 name: 'projectName',
                 message: 'Project name',
-                default: this.appname,
+                default: this.appname.replace(/ /g, '-'),
                 validate: validateProjectName,
             },
             {

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -21,13 +21,14 @@ class SymfonyGenerator extends PackageGenerator<Options> {
 
     async prompting() {
         const { packageName } = this.options;
+        const projectName = this.config.get('projectName');
 
         this.#answers = await this.prompt([
             {
                 type: 'input',
                 name: 'domain',
                 message: `The domain for ${packageName}`,
-                default: `${packageName}.${this.appname}.thetribe.io`,
+                default: `${packageName}.${projectName}.thetribe.io`,
             },
         ]);
     }


### PR DESCRIPTION
When running in a folder with dashes, the generator was replacing dashes with spaces in project name and domains default values, this fixes it.