### PR TITLE
Remove install steps from generators

### DIFF
--- a/generators/create-react-app/index.test.ts
+++ b/generators/create-react-app/index.test.ts
@@ -15,8 +15,9 @@ describe('When running the generator', () => {
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false })
             .withArguments(['test']);
+
+        await execa('yarn', ['install', '--frozen-lockfile'], { cwd: path.resolve(root, 'test') });
     });
 
     afterAll(async () => {

--- a/generators/create-react-app/index.ts
+++ b/generators/create-react-app/index.ts
@@ -36,12 +36,6 @@ class CreateReactAppGenerator extends PackageGenerator {
             repositoryName: this.config.get('repositoryName'),
         });
     }
-
-    install(): void {
-        const { packageName } = this.options;
-
-        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
-    }
 }
 
 export default CreateReactAppGenerator;

--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -16,8 +16,9 @@ describe('When running the generator', () => {
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false })
             .withArguments([packageName]);
+
+        await execa('yarn', ['install', '--frozen-lockfile'], { cwd: path.resolve(root, 'test') });
     });
 
     afterAll(async () => {

--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -42,12 +42,6 @@ class ExpressGenerator extends PackageGenerator {
             repositoryName: this.config.get('repositoryName'),
         });
     }
-
-    install(): void {
-        const { packageName } = this.options;
-
-        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
-    }
 }
 
 export default ExpressGenerator;

--- a/generators/next-js/index.test.ts
+++ b/generators/next-js/index.test.ts
@@ -16,8 +16,9 @@ describe('When running the generator', () => {
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false })
             .withArguments([packageName]);
+
+        await execa('yarn', ['install', '--frozen-lockfile'], { cwd: path.resolve(root, 'test') });
     });
 
     afterAll(async () => {

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -6,12 +6,6 @@ class NextJSGenerator extends PackageGenerator {
         this.renderTemplate('base', packageName);
         await this.configureDockerCompose('docker-compose.yaml.ejs', { packageName });
     }
-
-    install(): void {
-        const { packageName } = this.options;
-
-        this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
-    }
 }
 
 export default NextJSGenerator;

--- a/generators/symfony/index.test.ts
+++ b/generators/symfony/index.test.ts
@@ -16,8 +16,11 @@ describe('When running the generator', () => {
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ skipInstall: false, twig: true })
+            .withOptions({ twig: true })
             .withArguments(['test']);
+
+        await execa('composer', ['install', '--ignore-platform-reqs', '--no-scripts'], { cwd: path.resolve(root, 'test') });
+        await execa('yarn', ['install', '--frozen-lockfile'], { cwd: path.resolve(root, 'test') });
     });
 
     afterAll(async () => {

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -1,5 +1,4 @@
 import cryptoRandomString from 'crypto-random-string';
-import execa from 'execa';
 import PackageGenerator, { PackageGeneratorOptions } from '../../utils/PackageGenerator';
 
 interface Options extends PackageGeneratorOptions {
@@ -61,16 +60,6 @@ class SymfonyGenerator extends PackageGenerator<Options> {
             repositoryName: this.config.get('repositoryName'),
             twig: this.options.twig,
         });
-    }
-
-    async install(): Promise<void> {
-        const { packageName } = this.options;
-
-        await execa('composer', ['install', '--ignore-platform-reqs', '--no-scripts'], { cwd: this.destinationPath(packageName) });
-
-        if (this.options.twig) {
-            this.yarnInstall(undefined, { frozenLockfile: true }, { cwd: this.destinationPath(packageName) });
-        }
     }
 }
 


### PR DESCRIPTION
We can't expect users of the generator to have yarn and composer installed locally when we provide a docker environment with them included to prevent having to install yarn and composer to use the project.

An alternative could be to use docker in the install step, I will try making a PR to test the approach.