### PR TITLE
Add tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "crypto-random-string": "^3.3.1",
     "ejs": "^3.1.6",
     "ramda": "^0.27.1",
+    "tslib": "^2.2.0",
     "yaml": "^1.10.2",
     "yeoman-generator": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5752,6 +5752,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"


### PR DESCRIPTION
tslib is required since we use `"importHelpers": true`, this probably wasn't creating bugs because some of our dependencies where requiring it.