### PR TITLE
Replace automatic installation of dependency with a script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,29 +38,27 @@ jobs:
           at: .
       - run: yarn build
 
-  test:
+  test-utils:
     executor: node
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: sudo apt install ansible apt-transport-https
-      - php/install-php:
-          version: '8.0'
-      - run: sudo apt install php8.0-intl php8.0-mbstring
-      - php/install-composer:
-          install-version: 2.0.11
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - yarn-cache-{{ .Branch }}
-            - yarn-cache
-      - run: yarn test
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: yarn-cache-{{ .Branch }}
-          paths:
-            - ~/.cache/yarn
+      - run: sudo apt install ansible
+      - run: yarn test:utils
+
+  test-generators:
+    machine:
+      image: ubuntu-2004:202104-01
+    steps:
+      - node/install:
+          install-npm: false
+          install-yarn: true
+          node-version: 14.15.1
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: yarn test:generators
 
 workflows:
   version: '2'
@@ -72,7 +70,10 @@ workflows:
             - yarn-install
       - build:
           requires:
-            - lint
-      - test:
+            - yarn-install
+      - test-utils:
           requires:
-            - lint
+            - yarn-install
+      - test-generators:
+          requires:
+            - yarn-install

--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -87,6 +87,10 @@ class AppGenerator extends Generator {
                 break;
         }
     }
+
+    end(): void {
+        this.log('Your project was successfully generated, you can now start it with the ./script/server command.');
+    }
 }
 
 export default AppGenerator;

--- a/generators/create-react-app/index.test.ts
+++ b/generators/create-react-app/index.test.ts
@@ -16,18 +16,25 @@ describe('When running the generator', () => {
         await helpers.run(__dirname)
             .cd(root)
             .withArguments(['test']);
+
+        await execa(path.resolve(root, 'script', 'bootstrap'));
     });
 
     afterAll(async () => {
+        await execa('docker-compose', ['down', '--rmi', 'local', '--volumes'], { cwd: root });
         await fs.promises.rm(root, { recursive: true });
     });
 
+    const run = async (container: string, command: string, args: string[]): Promise<void> => {
+        await execa('docker-compose', ['run', '--rm', '--no-deps', container, command, ...args], { cwd: root });
+    };
+
     test('It generates a project which correctly builds', async () => {
-        await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
+        await run('test', 'yarn', ['build']);
     });
 
     test('It generates a project which correctly lints', async () => {
-        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
+        await run('test', 'yarn', ['lint']);
     });
 
     test('It generates a docker-compose.yaml with a version fields', async () => {

--- a/generators/create-react-app/index.ts
+++ b/generators/create-react-app/index.ts
@@ -35,12 +35,8 @@ class CreateReactAppGenerator extends PackageGenerator {
             domain,
             repositoryName: this.config.get('repositoryName'),
         });
-    }
 
-    async install(): Promise<void> {
-        const { packageName } = this.options;
-
-        await this.spawnCommand('yarn', ['install', '--frozen-lockfile'], { cwd: this.destinationPath(packageName) });
+        await this.configureScripts('script');
     }
 }
 

--- a/generators/create-react-app/templates/base/docker/Dockerfile.ejs
+++ b/generators/create-react-app/templates/base/docker/Dockerfile.ejs
@@ -2,8 +2,8 @@ FROM node:14.17.1
 
 RUN userdel node
 
-ARG UID=1000
-RUN useradd --uid $UID --create-home user
+ARG UID
+RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
 WORKDIR /usr/src/project/<%= packageName %>

--- a/generators/create-react-app/templates/docker-compose.yaml.ejs
+++ b/generators/create-react-app/templates/docker-compose.yaml.ejs
@@ -1,6 +1,9 @@
 services:
     <%= packageName %>:
-        build: <%= packageName %>/docker
+        build:
+            context: <%= packageName %>/docker
+            args:
+                UID: ${UID:-1000}
         volumes:
             - ./<%= packageName %>:/usr/src/project/<%= packageName %>
         environment:

--- a/generators/create-react-app/templates/script/bootstrap.ejs
+++ b/generators/create-react-app/templates/script/bootstrap.ejs
@@ -1,0 +1,2 @@
+
+docker-compose run --rm --no-deps <%= packageName %> yarn install --frozen-lockfile

--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -17,18 +17,25 @@ describe('When running the generator', () => {
         await helpers.run(__dirname)
             .cd(root)
             .withArguments([packageName]);
+
+        await execa(path.resolve(root, 'script', 'bootstrap'));
     });
 
     afterAll(async () => {
+        await execa('docker-compose', ['down', '--rmi', 'local', '--volumes'], { cwd: root });
         await fs.promises.rm(root, { recursive: true });
     });
 
+    const run = async (container: string, command: string, args: string[]): Promise<void> => {
+        await execa('docker-compose', ['run', '--rm', '--no-deps', container, command, ...args], { cwd: root });
+    };
+
     test('It generates a project which correctly builds', async () => {
-        await execa('yarn', ['build'], { cwd: path.resolve(root, packageName) });
+        await run('test', 'yarn', ['build']);
     });
 
     test('It generates a project which correctly lints', async () => {
-        await execa('yarn', ['lint'], { cwd: path.resolve(root, packageName) });
+        await run('test', 'yarn', ['lint']);
     });
 
     test('It generates a docker-compose.yaml with the right fields', async () => {

--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -41,12 +41,8 @@ class ExpressGenerator extends PackageGenerator {
             domain,
             repositoryName: this.config.get('repositoryName'),
         });
-    }
 
-    async install(): Promise<void> {
-        const { packageName } = this.options;
-
-        await this.spawnCommand('yarn', ['install', '--frozen-lockfile'], { cwd: this.destinationPath(packageName) });
+        await this.configureScripts('script');
     }
 }
 

--- a/generators/express/templates/base/docker/Dockerfile.ejs
+++ b/generators/express/templates/base/docker/Dockerfile.ejs
@@ -2,8 +2,8 @@ FROM node:14.17.1
 
 RUN userdel node
 
-ARG UID=1000
-RUN useradd --uid $UID --create-home user
+ARG UID
+RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
 WORKDIR /usr/src/project/<%= packageName %>

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -1,6 +1,9 @@
 services:
     <%= packageName %>:
-        build: <%= packageName %>/docker
+        build:
+            context: <%= packageName %>/docker
+            args:
+                UID: ${UID:-1000}
         volumes:
             - ./<%= packageName %>:/usr/src/project/<%= packageName %>
         environment:

--- a/generators/express/templates/script/bootstrap.ejs
+++ b/generators/express/templates/script/bootstrap.ejs
@@ -1,0 +1,2 @@
+
+docker-compose run --rm --no-deps <%= packageName %> yarn install --frozen-lockfile

--- a/generators/next-js/index.test.ts
+++ b/generators/next-js/index.test.ts
@@ -17,18 +17,25 @@ describe('When running the generator', () => {
         await helpers.run(__dirname)
             .cd(root)
             .withArguments([packageName]);
+
+        await execa(path.resolve(root, 'script', 'bootstrap'));
     });
 
     afterAll(async () => {
+        await execa('docker-compose', ['down', '--rmi', 'local', '--volumes'], { cwd: root });
         await fs.promises.rm(root, { recursive: true });
     });
 
+    const run = async (container: string, command: string, args: string[]): Promise<void> => {
+        await execa('docker-compose', ['run', '--rm', '--no-deps', container, command, ...args], { cwd: root });
+    };
+
     test('It generates a project which correctly lints', async () => {
-        await execa('yarn', ['lint'], { cwd: path.resolve(root, 'test') });
+        await run('test', 'yarn', ['lint']);
     });
 
     test('It generates a project which correctly builds', async () => {
-        await execa('yarn', ['build'], { cwd: path.resolve(root, 'test') });
+        await run('test', 'yarn', ['build']);
     });
 
     test('It generates a docker-compose.yaml with the right fields', async () => {

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -8,12 +8,8 @@ class NextJSGenerator extends PackageGenerator {
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 
         await this.configureCircleCI('circleci.yaml.ejs');
-    }
 
-    async install(): Promise<void> {
-        const { packageName } = this.options;
-
-        await this.spawnCommand('yarn', ['install', '--frozen-lockfile'], { cwd: this.destinationPath(packageName) });
+        await this.configureScripts('script');
     }
 }
 

--- a/generators/next-js/templates/base/docker/Dockerfile.ejs
+++ b/generators/next-js/templates/base/docker/Dockerfile.ejs
@@ -2,8 +2,8 @@ FROM node:14.17.1
 
 RUN userdel node
 
-ARG UID=1000
-RUN useradd --uid $UID --create-home user
+ARG UID
+RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
 WORKDIR /usr/src/project/<%= packageName %>

--- a/generators/next-js/templates/docker-compose.yaml.ejs
+++ b/generators/next-js/templates/docker-compose.yaml.ejs
@@ -1,6 +1,9 @@
 services:
     <%= packageName %>:
-        build: <%= packageName %>/docker
+        build:
+            context: <%= packageName %>/docker
+            args:
+                UID: ${UID:-1000}
         volumes:
             - ./<%= packageName %>:/usr/src/project/<%= packageName %>
         environment:

--- a/generators/next-js/templates/script/bootstrap.ejs
+++ b/generators/next-js/templates/script/bootstrap.ejs
@@ -1,0 +1,2 @@
+
+docker-compose run --rm --no-deps <%= packageName %> yarn install --frozen-lockfile

--- a/generators/root/index.ts
+++ b/generators/root/index.ts
@@ -58,7 +58,10 @@ class RootGenerator extends Generator {
         this.writeDestination('ansible/vault_pass.txt', `${vaultPass}\n`);
     }
 
-    async install() {
+    async install(): Promise<void> {
+        // Yeoman is loosing file permisions when writing
+        await this.spawnCommand('chmod', ['a+x', 'script/bootstrap', 'script/server', 'script/update']);
+
         await this.spawnCommand('git', ['init']);
 
         if (!(await this.#spawnTest('git', ['remote', 'get-url', 'origin']))) {

--- a/generators/root/templates/base/script/bootstrap
+++ b/generators/root/templates/base/script/bootstrap
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Resolve all dependencies that the application requires to run.
+
+set -e
+
+cd $(dirname $(dirname $0))
+
+. script/lib/docker

--- a/generators/root/templates/base/script/lib/docker
+++ b/generators/root/templates/base/script/lib/docker
@@ -1,0 +1,7 @@
+# Setup env variables passed to the docker config
+export UID=$(id -u)
+
+# Detect docker rootless mode
+if [ "$DOCKER_HOST" = "unix:///run/user/$UID/docker.sock" ]; then
+    export UID=0
+fi

--- a/generators/root/templates/base/script/server
+++ b/generators/root/templates/base/script/server
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Launch the application and any extra required processes locally.
+
+set -e
+
+cd $(dirname $(dirname $0))
+
+script/update
+
+. script/lib/docker
+
+docker-compose up

--- a/generators/root/templates/base/script/update
+++ b/generators/root/templates/base/script/update
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Update application to run for its current checkout.
+
+set -e
+
+cd $(dirname $(dirname $0))
+
+script/bootstrap

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -60,16 +60,8 @@ class SymfonyGenerator extends PackageGenerator<Options> {
             repositoryName: this.config.get('repositoryName'),
             twig: this.options.twig,
         });
-    }
 
-    async install(): Promise<void> {
-        const { packageName } = this.options;
-
-        await this.spawnCommand('composer', ['install', '--ignore-platform-reqs', '--no-scripts'], { cwd: this.destinationPath(packageName) });
-
-        if (this.options.twig) {
-            await this.spawnCommand('yarn', ['install', '--frozen-lockfile'], { cwd: this.destinationPath(packageName) });
-        }
+        await this.configureScripts('script', { twig: this.options.twig });
     }
 }
 

--- a/generators/symfony/templates/base-twig/docker/node/Dockerfile.ejs
+++ b/generators/symfony/templates/base-twig/docker/node/Dockerfile.ejs
@@ -1,8 +1,8 @@
 FROM node:14.17.1
 
 # Configure permissions
-ARG UID=1000
-RUN userdel node && useradd --uid $UID --create-home user
+ARG UID
+RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
 WORKDIR /usr/src/project/<%= packageName %>

--- a/generators/symfony/templates/base/docker/php/Dockerfile.ejs
+++ b/generators/symfony/templates/base/docker/php/Dockerfile.ejs
@@ -18,8 +18,8 @@ RUN curl -f -L "https://getcomposer.org/download/2.0.8/composer.phar" -o /usr/lo
     chmod 755 /usr/local/bin/composer
 
 # Configure permissions
-ARG UID=1000
-RUN useradd --uid $UID --create-home user
+ARG UID
+RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
 WORKDIR /usr/src/project/<%= packageName %>

--- a/generators/symfony/templates/docker-compose-twig.yaml.ejs
+++ b/generators/symfony/templates/docker-compose-twig.yaml.ejs
@@ -9,7 +9,10 @@ services:
             - <%= packageName %>-php
 
     <%= packageName %>-node:
-        build: <%= packageName %>/docker/node
+        build:
+            context: <%= packageName %>/docker/node
+            args:
+                UID: ${UID:-1000}
         command: yarn start
         depends_on:
             - <%= packageName %>-nginx

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -11,7 +11,10 @@ services:
             - 8080:80
 
     <%= packageName %>-php:
-        build: <%= packageName %>/docker/php
+        build:
+            context: <%= packageName %>/docker/php
+            args:
+                UID: ${UID:-1000}
         environment:
             DATABASE_URL: "postgresql://user:password@postgres:5432/thetribe"
         depends_on:

--- a/generators/symfony/templates/script/bootstrap.ejs
+++ b/generators/symfony/templates/script/bootstrap.ejs
@@ -1,0 +1,5 @@
+
+docker-compose run --rm --no-deps <%= packageName %>-php composer install --ignore-platform-reqs --no-scripts
+<% if (twig) { %>
+docker-compose run --rm --no-deps <%= packageName %>-node yarn install --frozen-lockfile
+<% } %>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "rm -fr dist && tsc --project tsconfig.build.json && copyfiles --all --exclude '**/node_modules/**' 'generators/*/templates/**/*' dist && cp package.json README.md dist/",
     "lint": "eslint --ext ts generators utils",
     "test": "yarn test:utils && yarn test:generators",
-    "test:generators": "jest --runInBand --testTimeout 120000 generators",
+    "test:generators": "jest --runInBand --testTimeout 300000 generators",
     "test:utils": "jest utils",
     "test:utils:coverage": "yarn test:utils --coverage --collectCoverageFrom 'utils/**/*'"
   }

--- a/utils/PackageGenerator.ts
+++ b/utils/PackageGenerator.ts
@@ -74,6 +74,14 @@ class PackageGenerator<T extends PackageGeneratorOptions = PackageGeneratorOptio
         }));
     }
 
+    async configureScripts(templatePath: string, context: TemplateData = {}): Promise<void> {
+        const scripts = ['bootstrap'];
+
+        await Promise.all(scripts.map(async (script: string): Promise<void> => {
+            await this.appendTemplate(`${templatePath}/${script}.ejs`, `script/${script}`, context);
+        }));
+    }
+
     private async appendTemplate(from: string, to: string, context: TemplateData): Promise<void> {
         this.fs.append(this.destinationPath(to), await this.renderTemplateToString(from, context));
     }


### PR DESCRIPTION
Automatic installation of dependency expect the package manager to be
installed on the host system while the project is then made to use
docker for such steps. This commit removes the automatic installation
and instead provides a script that install all required dependencies.

The names of the scripts where inspired by https://github.com/github/scripts-to-rule-them-all

This PR replaces https://github.com/thetribeio/generator-project/pull/204