### PR TITLE
Add GitHub workflow to automaticaly update node

### DIFF
--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,2 @@
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,21 @@
+name: 'Update dependencies'
+on:
+  schedule:
+    - cron:  '0 4 * * *'
+
+jobs:
+  update-node:
+    name: Update Node
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+      - name: Update version
+        id: update
+        run: ./scripts/updateNode.ts
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update Node to v${{ steps.update.outputs.version }}
+          body: Update Node to last LTS version
+          branch: update/node
+          title: Update Node to v${{ steps.update.outputs.version }}

--- a/scripts/updateNode.ts
+++ b/scripts/updateNode.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+import { dirname, fromFileUrl, join } from "https://deno.land/std@0.98.0/path/mod.ts";
+import { compare } from "https://deno.land/x/semver@v1.4.0/mod.ts";
+
+const root = dirname(dirname(fromFileUrl(import.meta.url)));
+
+const replace = async (file: string, regexp: RegExp, replacer: string) => {
+    const path = join(root, file);
+
+    const content = await Deno.readTextFile(path);
+
+    await Deno.writeTextFile(path, content.replace(regexp, replacer));
+};
+
+interface Version {
+    version: string;
+    lts: string|false;
+}
+
+const versions: Version[] = await (await fetch('https://nodejs.org/dist/index.json')).json();
+
+const lastLts = versions
+    .filter((version) => version.lts !== false)
+    .sort((a, b) => compare(a.version, b.version))
+    .pop();
+
+if (!lastLts) {
+    throw new Error('No LTS found.');
+}
+
+const lastVersion = lastLts.version.replace(/^v/, '');
+
+// Update CircleCI config
+await replace('generators/root/templates/base/.circleci/config.yml', /image: circleci\/node:\d+\.\d+\.\d+/, `image: circleci/node:${lastVersion}`);
+
+// Update Dockerfiles
+for (const file of [
+    'generators/create-react-app/templates/base/docker/Dockerfile.ejs',
+    'generators/express/templates/base/docker/Dockerfile.ejs',
+    'generators/next-js/templates/base/docker/Dockerfile.ejs',
+    'generators/symfony/templates/base-twig/docker/node/Dockerfile.ejs'
+]) {
+    await replace(file, /FROM node:\d+\.\d+\.\d+/, `FROM node:${lastVersion}`);
+}
+
+console.log(`::set-output name=version::${lastVersion}`);


### PR DESCRIPTION
Fix https://github.com/thetribeio/generator-project/issues/336

This creates PRs like [this](https://github.com/jvasseur/generator-project/pull/1) that automatically update node to the latest LTS version.

I decided to use Deno instead of Node to simplify the workflow by not requiring to install dependencies and compile the TS file.

It doesn't work yet for major versions where more thing needs updating, but we have a few months before we have to worry about that.