### PR TITLE
Disable engine update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,13 @@
 {
     "extends": [
         "@thetribe"
+    ],
+    "packageRules": [
+        {
+            "matchDepTypes": [
+                "engines"
+            ],
+            "enabled": false
+        }
     ]
 }


### PR DESCRIPTION
Disable PRs like https://github.com/thetribeio/generator-project/pull/156

We don't want the engine constraint to always be updated to the last version since we want to stay compatible with a wider range of versions.