### PR TITLE
Add a package path option to package generators

### DIFF
--- a/generators/create-react-app/index.test.ts
+++ b/generators/create-react-app/index.test.ts
@@ -49,3 +49,26 @@ describe('When running the generator', () => {
         expect(all.test_data).toBeDefined();
     });
 });
+
+describe('When running the generator with the path option', () => {
+    let root: string;
+
+    beforeAll(async () => {
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
+            .withPrompts({ contactEmail: 'test@example.com' });
+
+        root = result.cwd;
+
+        await helpers.run(__dirname)
+            .cd(root)
+            .withArguments(['test', '--path', 'packages/test']);
+    });
+
+    afterAll(async () => {
+        await fs.promises.rm(root, { recursive: true });
+    });
+
+    test('It generates the project in the given directory', async () => {
+        expect(fs.existsSync(path.join(root, 'packages/test'))).toBe(true);
+    });
+});

--- a/generators/create-react-app/index.ts
+++ b/generators/create-react-app/index.ts
@@ -22,10 +22,10 @@ class CreateReactAppGenerator extends PackageGenerator {
     }
 
     async writing(): Promise<void> {
-        const { packageName } = this.options;
+        const { packagePath } = this.options;
         const { domain } = this.#answers as Prompt;
 
-        this.renderTemplate('base', packageName, undefined, undefined, { globOptions: { dot: true } });
+        this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 

--- a/generators/create-react-app/templates/base/docker/Dockerfile.ejs
+++ b/generators/create-react-app/templates/base/docker/Dockerfile.ejs
@@ -6,8 +6,8 @@ ARG UID
 RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= packageName %>
+WORKDIR /usr/src/project/<%= packagePath %>
 
-ENV PATH="/usr/src/project/<%= packageName %>/node_modules/.bin:${PATH}"
+ENV PATH="/usr/src/project/<%= packagePath %>/node_modules/.bin:${PATH}"
 
 CMD ["yarn", "start"]

--- a/generators/create-react-app/templates/circleci.yaml.ejs
+++ b/generators/create-react-app/templates/circleci.yaml.ejs
@@ -4,17 +4,17 @@ jobs:
     steps:
       - checkout
       - node/install-packages:
-          app-dir: <%= packageName %>
+          app-dir: <%= packagePath %>
           include-branch-in-cache-key: false
           pkg-manager: yarn
       - persist_to_workspace:
           root: .
           paths:
-              - <%= packageName %>/node_modules
+              - <%= packagePath %>/node_modules
 
   <%= packageName %>-lint:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -25,7 +25,7 @@ jobs:
 
   <%= packageName %>-build:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -39,11 +39,11 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-              - <%= packageName %>/build
+              - <%= packagePath %>/build
 
   <%= packageName %>-archive:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -68,7 +68,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: sentry-cli releases new <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
-      - run: sentry-cli releases files <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1} upload-sourcemaps <%= packageName %>/build
+      - run: sentry-cli releases files <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1} upload-sourcemaps <%= packagePath %>/build
       - run: sentry-cli releases finalize <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
 
 workflows:

--- a/generators/create-react-app/templates/docker-compose.yaml.ejs
+++ b/generators/create-react-app/templates/docker-compose.yaml.ejs
@@ -1,11 +1,11 @@
 services:
     <%= packageName %>:
         build:
-            context: <%= packageName %>/docker
+            context: <%= packagePath %>/docker
             args:
                 UID: ${UID:-1000}
         volumes:
-            - ./<%= packageName %>:/usr/src/project/<%= packageName %>
+            - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
             PORT: ${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-3000}
         ports:

--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -50,3 +50,26 @@ describe('When running the generator', () => {
         expect(all.test_env).toBeDefined();
     });
 });
+
+describe('When running the generator with the path option', () => {
+    let root: string;
+
+    beforeAll(async () => {
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
+            .withPrompts({ contactEmail: 'test@example.com' });
+
+        root = result.cwd;
+
+        await helpers.run(__dirname)
+            .cd(root)
+            .withArguments(['test', '--path', 'packages/test']);
+    });
+
+    afterAll(async () => {
+        await fs.promises.rm(root, { recursive: true });
+    });
+
+    test('It generates the project in the given directory', async () => {
+        expect(fs.existsSync(path.join(root, 'packages/test'))).toBe(true);
+    });
+});

--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -23,14 +23,14 @@ class ExpressGenerator extends PackageGenerator {
     }
 
     async writing() {
-        const { packageName } = this.options;
+        const { packagePath } = this.options;
         const { domain } = this.#answers as Prompt;
 
         // We use only alphanumeric characters in database password because special
         // characters often causes problems in configuration files
         const databasePassword = cryptoRandomString({ length: 64, type: 'alphanumeric' });
 
-        this.renderTemplate('base', packageName, undefined, undefined, { globOptions: { dot: true } });
+        this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 

--- a/generators/express/templates/base/docker/Dockerfile.ejs
+++ b/generators/express/templates/base/docker/Dockerfile.ejs
@@ -6,8 +6,8 @@ ARG UID
 RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= packageName %>
+WORKDIR /usr/src/project/<%= packagePath %>
 
-ENV PATH="/usr/src/project/<%= packageName %>/node_modules/.bin:${PATH}"
+ENV PATH="/usr/src/project/<%= packagePath %>/node_modules/.bin:${PATH}"
 
 CMD ["yarn", "start"]

--- a/generators/express/templates/circleci.yaml.ejs
+++ b/generators/express/templates/circleci.yaml.ejs
@@ -4,17 +4,17 @@ jobs:
     steps:
       - checkout
       - node/install-packages:
-          app-dir: <%= packageName %>
+          app-dir: <%= packagePath %>
           include-branch-in-cache-key: false
           pkg-manager: yarn
       - persist_to_workspace:
           root: .
           paths:
-              - <%= packageName %>/node_modules
+              - <%= packagePath %>/node_modules
 
   <%= packageName %>-lint:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -25,7 +25,7 @@ jobs:
 
   <%= packageName %>-build:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -39,11 +39,11 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-              - <%= packageName %>/dist
+              - <%= packagePath %>/dist
 
   <%= packageName %>-archive:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -71,7 +71,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: sentry-cli releases new <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
-      - run: sentry-cli releases files <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1} upload-sourcemaps <%= packageName %>/dist
+      - run: sentry-cli releases files <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1} upload-sourcemaps <%= packagePath %>/dist
       - run: sentry-cli releases finalize <%= projectName %>-<%= packageName %>@${CIRCLE_SHA1}
 
 workflows:

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -1,11 +1,11 @@
 services:
     <%= packageName %>:
         build:
-            context: <%= packageName %>/docker
+            context: <%= packagePath %>/docker
             args:
                 UID: ${UID:-1000}
         volumes:
-            - ./<%= packageName %>:/usr/src/project/<%= packageName %>
+            - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
             PORT: ${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-4000}
         ports:

--- a/generators/next-js/index.test.ts
+++ b/generators/next-js/index.test.ts
@@ -44,3 +44,26 @@ describe('When running the generator', () => {
         expect(all.services[packageName]).toBeDefined();
     });
 });
+
+describe('When running the generator with the path option', () => {
+    let root: string;
+
+    beforeAll(async () => {
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
+            .withPrompts({ contactEmail: 'test@example.com' });
+
+        root = result.cwd;
+
+        await helpers.run(__dirname)
+            .cd(root)
+            .withArguments(['test', '--path', 'packages/test']);
+    });
+
+    afterAll(async () => {
+        await fs.promises.rm(root, { recursive: true });
+    });
+
+    test('It generates the project in the given directory', async () => {
+        expect(fs.existsSync(path.join(root, 'packages/test'))).toBe(true);
+    });
+});

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -2,8 +2,8 @@ import PackageGenerator from '../../utils/PackageGenerator';
 
 class NextJSGenerator extends PackageGenerator {
     async writing() {
-        const { packageName } = this.options;
-        this.renderTemplate('base', packageName, undefined, undefined, { globOptions: { dot: true } });
+        const { packagePath } = this.options;
+        this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 

--- a/generators/next-js/templates/base/docker/Dockerfile.ejs
+++ b/generators/next-js/templates/base/docker/Dockerfile.ejs
@@ -6,8 +6,8 @@ ARG UID
 RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= packageName %>
+WORKDIR /usr/src/project/<%= packagePath %>
 
-ENV PATH="/usr/src/project/<%= packageName %>/node_modules/.bin:${PATH}"
+ENV PATH="/usr/src/project/<%= packagePath %>/node_modules/.bin:${PATH}"
 
 CMD ["yarn", "dev"]

--- a/generators/next-js/templates/circleci.yaml.ejs
+++ b/generators/next-js/templates/circleci.yaml.ejs
@@ -4,17 +4,17 @@ jobs:
     steps:
       - checkout
       - node/install-packages:
-          app-dir: <%= packageName %>
+          app-dir: <%= packagePath %>
           include-branch-in-cache-key: false
           pkg-manager: yarn
       - persist_to_workspace:
           root: .
           paths:
-              - <%= packageName %>/node_modules
+              - <%= packagePath %>/node_modules
 
   <%= packageName %>-lint:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -25,7 +25,7 @@ jobs:
 
   <%= packageName %>-build:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -39,11 +39,11 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-              - <%= packageName %>/build
+              - <%= packagePath %>/build
 
   <%= packageName %>-archive:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project

--- a/generators/next-js/templates/docker-compose.yaml.ejs
+++ b/generators/next-js/templates/docker-compose.yaml.ejs
@@ -1,11 +1,11 @@
 services:
     <%= packageName %>:
         build:
-            context: <%= packageName %>/docker
+            context: <%= packagePath %>/docker
             args:
                 UID: ${UID:-1000}
         volumes:
-            - ./<%= packageName %>:/usr/src/project/<%= packageName %>
+            - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
             PORT: ${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-3000}
         ports:

--- a/generators/symfony/index.test.ts
+++ b/generators/symfony/index.test.ts
@@ -52,3 +52,26 @@ describe('When running the generator', () => {
         expect(all.test_env).toBeDefined();
     });
 });
+
+describe('When running the generator with the path option', () => {
+    let root: string;
+
+    beforeAll(async () => {
+        const result = await helpers.run(path.resolve(__dirname, '../root'))
+            .withPrompts({ contactEmail: 'test@example.com' });
+
+        root = result.cwd;
+
+        await helpers.run(__dirname)
+            .cd(root)
+            .withArguments(['test', '--path', 'packages/test']);
+    });
+
+    afterAll(async () => {
+        await fs.promises.rm(root, { recursive: true });
+    });
+
+    test('It generates the project in the given directory', async () => {
+        expect(fs.existsSync(path.join(root, 'packages/test'))).toBe(true);
+    });
+});

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -33,21 +33,21 @@ class SymfonyGenerator extends PackageGenerator<Options> {
     }
 
     async writing() {
-        const { packageName } = this.options;
+        const { packagePath } = this.options;
         const { domain } = this.#answers as Prompt;
 
         // We use only alphanumeric characters in database password because special
         // characters often causes problems in configuration files
         const databasePassword = cryptoRandomString({ length: 64, type: 'alphanumeric' });
 
-        this.renderTemplate('base', packageName, undefined, undefined, { globOptions: { dot: true } });
+        this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 
         await this.configureCircleCI('circleci.yaml.ejs');
 
         if (this.options.twig) {
-            this.renderTemplate('base-twig', packageName, undefined, undefined, { globOptions: { dot: true } });
+            this.renderTemplate('base-twig', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
             await this.configureDockerCompose('docker-compose-twig.yaml.ejs');
 

--- a/generators/symfony/templates/base-twig/docker/node/Dockerfile.ejs
+++ b/generators/symfony/templates/base-twig/docker/node/Dockerfile.ejs
@@ -5,4 +5,4 @@ ARG UID
 RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= packageName %>
+WORKDIR /usr/src/project/<%= packagePath %>

--- a/generators/symfony/templates/base/docker/nginx/default.conf.ejs
+++ b/generators/symfony/templates/base/docker/nginx/default.conf.ejs
@@ -1,5 +1,5 @@
 server {
-    root /usr/src/project/<%= packageName %>/public;
+    root /usr/src/project/<%= packagePath %>/public;
 
     location / {
         # try to serve file directly, fallback to index.php

--- a/generators/symfony/templates/base/docker/php/Dockerfile.ejs
+++ b/generators/symfony/templates/base/docker/php/Dockerfile.ejs
@@ -22,4 +22,4 @@ ARG UID
 RUN useradd --non-unique --uid $UID --create-home user
 USER user
 
-WORKDIR /usr/src/project/<%= packageName %>
+WORKDIR /usr/src/project/<%= packagePath %>

--- a/generators/symfony/templates/circleci-twig.yaml.ejs
+++ b/generators/symfony/templates/circleci-twig.yaml.ejs
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   <%= packageName %>-build-assets:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -13,12 +13,12 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-            - <%= packageName %>/public/assets
-            - <%= packageName %>/var/manifest.json
+            - <%= packagePath %>/public/assets
+            - <%= packagePath %>/var/manifest.json
 
   <%= packageName %>-lint-js:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -28,7 +28,7 @@ jobs:
 
   <%= packageName %>-lint-scss:
     executor: node
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -38,7 +38,7 @@ jobs:
 
   <%= packageName %>-lint-twig:
     executor: php
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     environment:
       APP_ENV: prod
     steps:
@@ -54,7 +54,7 @@ jobs:
     executor: php
     environment:
       APP_ENV: prod
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -86,13 +86,13 @@ jobs:
     steps:
       - checkout
       - node/install-packages:
-          app-dir: <%= packageName %>
+          app-dir: <%= packagePath %>
           include-branch-in-cache-key: false
           pkg-manager: yarn
       - persist_to_workspace:
           root: .
           paths:
-            - <%= packageName %>/node_modules
+            - <%= packagePath %>/node_modules
 
 workflows:
   version: '2'

--- a/generators/symfony/templates/circleci.yaml.ejs
+++ b/generators/symfony/templates/circleci.yaml.ejs
@@ -4,7 +4,7 @@ jobs:
   <%= packageName %>-php-dependencies:
     docker:
       - image: composer/composer:2.0.11
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -20,11 +20,11 @@ jobs:
       - persist_to_workspace:
           root: ~/project
           paths:
-            - <%= packageName %>/vendor
+            - <%= packagePath %>/vendor
 
   <%= packageName %>-php-lint:
     executor: php
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -46,7 +46,7 @@ jobs:
         environment:
           POSTGRES_USER: thetribe
           POSTGRES_PASSWORD: 424242
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project
@@ -65,7 +65,7 @@ jobs:
     executor: php
     environment:
       APP_ENV: prod
-    working_directory: ~/project/<%= packageName %>
+    working_directory: ~/project/<%= packagePath %>
     steps:
       - checkout:
           path: ~/project

--- a/generators/symfony/templates/docker-compose-twig.yaml.ejs
+++ b/generators/symfony/templates/docker-compose-twig.yaml.ejs
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
     <%= packageName %>-nginx:
-        build: <%= packageName %>/docker/nginx
+        build: <%= packagePath %>/docker/nginx
         depends_on:
             - <%= packageName %>-php
         volumes_from:
@@ -10,7 +10,7 @@ services:
 
     <%= packageName %>-node:
         build:
-            context: <%= packageName %>/docker/node
+            context: <%= packagePath %>/docker/node
             args:
                 UID: ${UID:-1000}
         command: yarn start

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
     <%= packageName %>-nginx:
-        build: <%= packageName %>/docker/nginx
+        build: <%= packagePath %>/docker/nginx
         depends_on:
             - <%= packageName %>-php
         volumes_from:
@@ -12,7 +12,7 @@ services:
 
     <%= packageName %>-php:
         build:
-            context: <%= packageName %>/docker/php
+            context: <%= packagePath %>/docker/php
             args:
                 UID: ${UID:-1000}
         environment:
@@ -20,4 +20,4 @@ services:
         depends_on:
             - postgres
         volumes:
-            - ./<%= packageName %>:/usr/src/project/<%= packageName %>
+            - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>

--- a/utils/PackageGenerator.ts
+++ b/utils/PackageGenerator.ts
@@ -7,6 +7,7 @@ import Generator, { GeneratorOptions } from 'yeoman-generator';
 import { createEncrypt } from './ansible';
 import { Config, mergeConfig } from './circleci';
 import indent from './indent';
+import validateProjectPath from './validation/validatePackagePath';
 
 strOptions.fold.lineWidth = 0;
 
@@ -26,7 +27,16 @@ class PackageGenerator<T extends PackageGeneratorOptions = PackageGeneratorOptio
             throw new Error('Package name can only contains lowercase numbers, numbers and dashes');
         }
 
-        this.options.packagePath = this.options.path || this.options.packageName;
+        if (this.options.path) {
+            const validated = validateProjectPath(this.options.path);
+            if (validated === true) {
+                this.options.packagePath = this.options.path;
+            } else {
+                throw new Error(validated);
+            }
+        } else {
+            this.options.packagePath = this.options.packageName;
+        }
     }
 
     renderTemplate(

--- a/utils/PackageGenerator.ts
+++ b/utils/PackageGenerator.ts
@@ -12,6 +12,7 @@ strOptions.fold.lineWidth = 0;
 
 interface PackageGeneratorOptions extends GeneratorOptions {
     packageName: string;
+    packagePath: string;
 }
 
 class PackageGenerator<T extends PackageGeneratorOptions = PackageGeneratorOptions> extends Generator<T> {
@@ -19,10 +20,13 @@ class PackageGenerator<T extends PackageGeneratorOptions = PackageGeneratorOptio
         super(args, opts);
 
         this.argument('packageName', { type: String, required: true });
+        this.option('path', { type: String });
 
         if (!/^[a-z0-9-]+$/.test(this.options.name)) {
             throw new Error('Package name can only contains lowercase numbers, numbers and dashes');
         }
+
+        this.options.packagePath = this.options.path || this.options.packageName;
     }
 
     renderTemplate(
@@ -110,6 +114,7 @@ class PackageGenerator<T extends PackageGeneratorOptions = PackageGeneratorOptio
         return {
             indent,
             packageName: this.options.packageName,
+            packagePath: this.options.packagePath,
             projectName: this.config.get('projectName'),
             ...context,
         };

--- a/utils/validation/validatePackagePath.test.ts
+++ b/utils/validation/validatePackagePath.test.ts
@@ -1,0 +1,33 @@
+import validatePackagePath from './validatePackagePath';
+
+test('Path with null byte is not valid', () => {
+    expect(validatePackagePath('som\0e/path')).toBe('Path can\'t contain null bytes');
+});
+
+test('Absolute path is not valid', () => {
+    expect(validatePackagePath('/absolute/path')).toBe('Path can\'t be absolute');
+});
+
+test('Curent user home path is not valid', () => {
+    expect(validatePackagePath('~/test')).toBe('Path can\'t start with ~');
+});
+
+test('Other user home path is not valid', () => {
+    expect(validatePackagePath('~user/test')).toBe('Path can\'t start with ~');
+});
+
+test('Path with ".." segment is not valid', () => {
+    expect(validatePackagePath('../test')).toBe('Path can\'t contain parent directory segment');
+});
+
+test('Path with "." segment is not valid', () => {
+    expect(validatePackagePath('./test')).toBe('Path can\'t contain current directory segment');
+});
+
+test('Path with ".." in a segment is valid', () => {
+    expect(validatePackagePath('..test/test')).toBe(true);
+});
+
+test('Path with "." in a segment is valid', () => {
+    expect(validatePackagePath('.test/test')).toBe(true);
+});

--- a/utils/validation/validatePackagePath.ts
+++ b/utils/validation/validatePackagePath.ts
@@ -1,0 +1,34 @@
+/**
+ * Validate a project path so that it can't break out of the current projet and is cannonical.
+ */
+const validateProjectPath = (value: string): string|true => {
+    if (value.includes('\0')) {
+        return 'Path can\'t contain null bytes';
+    }
+
+    const start = value.substr(0, 1);
+
+    if (start === '/') {
+        return 'Path can\'t be absolute';
+    }
+
+    if (start === '~') {
+        return 'Path can\'t start with ~';
+    }
+
+    const segments = value.split('/');
+
+    for (const segment of segments) {
+        if (segment === '..') {
+            return 'Path can\'t contain parent directory segment';
+        }
+
+        if (segment === '.') {
+            return 'Path can\'t contain current directory segment';
+        }
+    }
+
+    return true;
+};
+
+export default validateProjectPath;


### PR DESCRIPTION
Add a package path option to allow generating a package in a different directory than one matching the package name.

This is useful for more complex repository structure like when hosting multiple projects in the same repository.