### PR TITLE
Fix database creation for Express and Symfony generators

### DIFF
--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -23,7 +23,7 @@ class ExpressGenerator extends PackageGenerator {
     }
 
     async writing() {
-        const { packagePath } = this.options;
+        const { packageName, packagePath } = this.options;
         const { domain } = this.#answers as Prompt;
 
         // We use only alphanumeric characters in database password because special
@@ -31,6 +31,8 @@ class ExpressGenerator extends PackageGenerator {
         const databasePassword = cryptoRandomString({ length: 64, type: 'alphanumeric' });
 
         this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
+
+        this.renderTemplate('database.sql.ejs', `postgres/docker/initdb.d/${packageName}.sql`);
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 

--- a/generators/express/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,5 @@
 <%= packageName.replace('-', '_') %>_env:
-  DATABASE_URL: postgres://<%= packageName %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName %>
+  DATABASE_URL: postgres://<%= packageName.replace('-', '_') %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName %>
   NODE_ENV: production
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
   SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/express/templates/ansible/provision.yaml.ejs
+++ b/generators/express/templates/ansible/provision.yaml.ejs
@@ -4,10 +4,10 @@
         name: postgresql
       vars:
         dbs:
-          <%= packageName %>:
-            owner: <%= packageName %>
+          <%= packageName.replace('-', '_') %>:
+            owner: <%= packageName.replace('-', '_') %>
         users:
-          <%= packageName %>:
+          <%= packageName.replace('-', '_') %>:
             password: '{{ <%= packageName.replace('-', '_') %>_database_password }}'
     - import_role:
         name: nodejs

--- a/generators/express/templates/database.sql.ejs
+++ b/generators/express/templates/database.sql.ejs
@@ -1,0 +1,1 @@
+CREATE DATABASE <%= packagePath.replace('-', '_') %> WITH OWNER 'user';

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -7,6 +7,7 @@ services:
         volumes:
             - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
+            DATABASE_URL: "postgresql://user:password@postgres/<%= packagePath.replace('-', '_') %>"
             PORT: ${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-4000}
         ports:
             - ${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-4000}:${<%= packageName.replace('-', '_').toUpperCase() %>_PORT:-4000}

--- a/generators/root/templates/base/docker-compose.yaml
+++ b/generators/root/templates/base/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
     postgres:
-        image: postgres:12.5
+        build: ./postgres/docker
         environment:
             PGUSER: user
             PGPASSWORD: password

--- a/generators/root/templates/base/postgres/docker/Dockerfile
+++ b/generators/root/templates/base/postgres/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12.5
+
+COPY ./initdb.d/ /docker-entrypoint-initdb.d/

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -33,7 +33,7 @@ class SymfonyGenerator extends PackageGenerator<Options> {
     }
 
     async writing() {
-        const { packagePath } = this.options;
+        const { packageName, packagePath } = this.options;
         const { domain } = this.#answers as Prompt;
 
         // We use only alphanumeric characters in database password because special
@@ -41,6 +41,8 @@ class SymfonyGenerator extends PackageGenerator<Options> {
         const databasePassword = cryptoRandomString({ length: 64, type: 'alphanumeric' });
 
         this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
+
+        this.renderTemplate('database.sql.ejs', `postgres/docker/initdb.d/${packageName}.sql`);
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 

--- a/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,5 @@
 <%= packageName.replace('-', '_') %>_env:
-  DATABASE_URL: postgresql://<%= packageName %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName %>
+  DATABASE_URL: postgresql://<%= packageName.replace('-', '_') %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName %>
   APP_ENV: prod
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
   SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/symfony/templates/ansible/provision.yaml.ejs
+++ b/generators/symfony/templates/ansible/provision.yaml.ejs
@@ -4,10 +4,10 @@
         name: postgresql
       vars:
         dbs:
-          <%= packageName %>:
-            owner: <%= packageName %>
+          <%= packageName.replace('-', '_') %>:
+            owner: <%= packageName.replace('-', '_') %>
         users:
-          <%= packageName %>:
+          <%= packageName.replace('-', '_') %>:
             password: '{{ <%= packageName.replace('-', '_') %>_database_password }}'
     - group:
         name: <%= packageName %>

--- a/generators/symfony/templates/database.sql.ejs
+++ b/generators/symfony/templates/database.sql.ejs
@@ -1,0 +1,1 @@
+CREATE DATABASE <%= packagePath.replace('-', '_') %> WITH OWNER 'user';

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -16,7 +16,7 @@ services:
             args:
                 UID: ${UID:-1000}
         environment:
-            DATABASE_URL: "postgresql://user:password@postgres:5432/thetribe"
+            DATABASE_URL: "postgresql://user:password@postgres/<%= packagePath.replace('-', '_') %>"
         depends_on:
             - postgres
         volumes:


### PR DESCRIPTION
- in development environment, databases where not creating for generators that require them
- in production/staging, database creation would fail for packages with dash in their names