### PR TITLE
Add submodule to index without cloning the repository

### DIFF
--- a/generators/root/index.ts
+++ b/generators/root/index.ts
@@ -68,9 +68,7 @@ class RootGenerator extends Generator {
             await this.spawnCommand('git', ['remote', 'add', 'origin', `git@github.com:${this.config.get('repositoryName')}.git`]);
         }
 
-        if (!(await this.#spawnTest('git', ['submodule', 'status', 'ansible/roles-lib']))) {
-            await this.spawnCommand('git', ['submodule', 'add', 'git@github.com:thetribeio/ansible-roles.git', 'ansible/roles-lib']);
-        }
+        await this.spawnCommand('git', ['update-index', '--add', '--cacheinfo', '160000', '4d1ffdcd4bc254bcc61fd85fc176d07b64d2d464', 'ansible/roles-lib']);
     }
 
     /**

--- a/generators/root/templates/base/.editorconfig
+++ b/generators/root/templates/base/.editorconfig
@@ -8,5 +8,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# Generated files
 [{package.json,yarn.lock}]
 indent_size = 2
+
+[.gitmodules]
+indent_style = tab

--- a/generators/root/templates/base/.gitmodules
+++ b/generators/root/templates/base/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ansible/roles-lib"]
+	path = ansible/roles-lib
+	url = git@github.com:thetribeio/ansible-roles.git


### PR DESCRIPTION
Only add the submodule to the index instead of cloning it:
 - This moves the responsability of cloning the submodule to the bootstrap script
 - This allow locking the submodule to a specific revision
 - This should make tests slightly faster