### PR TITLE
Add ansible config for NextJS generator

### DIFF
--- a/generators/express/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,7 @@
+<%= packageName.replace('-', '_') %>_port: 4000
 <%= packageName.replace('-', '_') %>_env:
   DATABASE_URL: postgres://<%= packageName.replace('-', '_') %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName.replace('-', '_') %>
   NODE_ENV: production
+  PORT: '{{ <%= packageName.replace('-', '_') %>_port }}'
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
   SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -1,13 +1,39 @@
 import PackageGenerator from '../../utils/PackageGenerator';
 
+interface Prompt {
+    domain: string,
+}
+
 class NextJSGenerator extends PackageGenerator {
+    #answers: Prompt|null = null;
+
+    async prompting() {
+        const { packageName } = this.options;
+        const projectName = this.config.get('projectName');
+
+        this.#answers = await this.prompt([
+            {
+                type: 'input',
+                name: 'domain',
+                message: `The domain for ${packageName}`,
+                default: `${packageName}.${projectName}.thetribe.io`,
+            },
+        ]);
+    }
+
     async writing() {
         const { packagePath } = this.options;
+        const { domain } = this.#answers as Prompt;
         this.renderTemplate('base', packagePath, undefined, undefined, { globOptions: { dot: true } });
 
         await this.configureDockerCompose('docker-compose.yaml.ejs');
 
         await this.configureCircleCI('circleci.yaml.ejs');
+
+        await this.configureAnsible('ansible', {
+            domain,
+            repositoryName: this.config.get('repositoryName'),
+        });
 
         await this.configureScripts('script');
     }

--- a/generators/next-js/templates/ansible/deployment.yaml.ejs
+++ b/generators/next-js/templates/ansible/deployment.yaml.ejs
@@ -1,0 +1,21 @@
+- hosts: server
+  tasks:
+    - import_role:
+        name: build
+      delegate_to: localhost
+    - import_role:
+        name: deploy
+      environment: '{{ <%= packageName.replace('-', '_') %>_env }}'
+      vars:
+        path: /home/<%= packageName %>
+        artifact_path: <%= packageName %>.tar.gz
+        after_finalize:
+          - systemctl restart <%= packageName %>
+  vars:
+    job_name: <%= packageName %>-archive
+    repository_name: <%= repositoryName %>
+  vars_files:
+    - vars/circleci.yaml
+    - vars/github.yaml
+  tags:
+    - <%= packageName %>

--- a/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
@@ -1,0 +1,5 @@
+<%= packageName.replace('-', '_') %>_port: 3000
+<%= packageName.replace('-', '_') %>_env:
+  NODE_ENV: production
+  SENTRY_DSN: ~ # TODO: Add your sentry DSN here
+  SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/next-js/templates/ansible/group_vars/staging.yaml.ejs
+++ b/generators/next-js/templates/ansible/group_vars/staging.yaml.ejs
@@ -1,0 +1,1 @@
+<%= packageName.replace('-', '_') %>_domain: <%= domain %>

--- a/generators/next-js/templates/ansible/provision.yaml.ejs
+++ b/generators/next-js/templates/ansible/provision.yaml.ejs
@@ -1,15 +1,6 @@
 - hosts: server
   tasks:
     - import_role:
-        name: postgresql
-      vars:
-        dbs:
-          <%= packageName.replace('-', '_') %>:
-            owner: <%= packageName.replace('-', '_') %>
-        users:
-          <%= packageName.replace('-', '_') %>:
-            password: '{{ <%= packageName.replace('-', '_') %>_database_password }}'
-    - import_role:
         name: nodejs
       vars:
         version: 14
@@ -20,7 +11,6 @@
         name: <%= packageName %>
         state: present
         group: <%= packageName %>
-        shell: /bin/bash
     - import_role:
         name: envfile
       vars:
@@ -34,7 +24,8 @@
     - import_role:
         name: service
       vars:
-        command: /usr/bin/node /home/<%= packageName %>/current/dist
+        working_directory: /home/<%= packageName %>/current
+        command: /home/<%= packageName %>/current/node_modules/.bin/next start --port {{ <%= packageName.replace('-', '_') %>_port }}
         description: <%= packageName %>
         service: <%= packageName %>
         user: <%= packageName %>
@@ -47,8 +38,6 @@
         site: <%= packageName %>
         domain: '{{ <%= packageName.replace('-', '_') %>_domain }}'
         config: |
-          root /home/<%= packageName %>/current/dist;
-
           client_max_body_size 25M;
 
           location / {

--- a/generators/next-js/templates/circleci.yaml.ejs
+++ b/generators/next-js/templates/circleci.yaml.ejs
@@ -50,10 +50,14 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
+          command: yarn install --prod --frozen-lockfile
+      - run:
           name: Create archive
           command: |
             tar --create --gzip --file=archive.tar.gz --owner=0 --group=0 \
               build/ \
+              next.config.js \
+              node_modules/ \
       - store_artifacts:
           path: archive.tar.gz
           destination: <%= packageName %>.tar.gz


### PR DESCRIPTION
This is mostly the same config as for express without the postgresql part.

I've added an ansible variable for the listening port to the express generator to simplify port conflict handling, we could go further and automatically generate an new unused port but it would be a lot of work for a case that only appends when running the generator in manual mode.

Fix  #330