### PR TITLE
Rename SENTRY_ENVIRONMENT variable to ENVIRONMENT_NAME

### DIFF
--- a/generators/create-react-app/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/create-react-app/templates/ansible/group_vars/all.yaml.ejs
@@ -1,3 +1,3 @@
 <%= packageName.replace('-', '_') %>_data:
+  environment-name: '{{ environment_name }}'
   sentry-dsn: ~ # TODO: Add your sentry DSN here
-  sentry-environment: '{{ environment_name }}'

--- a/generators/create-react-app/templates/base/src/index.tsx.ejs
+++ b/generators/create-react-app/templates/base/src/index.tsx.ejs
@@ -12,11 +12,11 @@ if (!root) {
     throw new Error('Missing root element');
 }
 
-const { sentryDsn, sentryEnvironment, ...props } = root.dataset;
+const { environmentName, sentryDsn, ...props } = root.dataset;
 
 Sentry.init({
     dsn: sentryDsn,
-    environment: sentryEnvironment,
+    environment: environmentName,
     release: version ? `<%= projectName %>-<%= packageName %>@${version}` : undefined,
 });
 

--- a/generators/express/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/all.yaml.ejs
@@ -1,7 +1,7 @@
 <%= packageName.replace('-', '_') %>_port: 4000
 <%= packageName.replace('-', '_') %>_env:
   DATABASE_URL: postgres://<%= packageName.replace('-', '_') %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName.replace('-', '_') %>
+  ENVIRONMENT_NAME: '{{ environment_name }}'
   NODE_ENV: production
   PORT: '{{ <%= packageName.replace('-', '_') %>_port }}'
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
-  SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/express/templates/base/src/index.ts.ejs
+++ b/generators/express/templates/base/src/index.ts.ejs
@@ -5,7 +5,7 @@ import version from './version';
 
 Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT,
+    environment: process.env.ENVIRONMENT_NAME,
     release: version ? `<%= projectName %>-<%= packageName %>@${version}` : undefined,
 });
 

--- a/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,5 @@
 <%= packageName.replace('-', '_') %>_port: 3000
 <%= packageName.replace('-', '_') %>_env:
+  ENVIRONMENT_NAME: '{{ environment_name }}'
   NODE_ENV: production
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
-  SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,5 @@
 <%= packageName.replace('-', '_') %>_env:
   DATABASE_URL: postgresql://<%= packageName.replace('-', '_') %>:{{ <%= packageName.replace('-', '_') %>_database_password }}@localhost/<%= packageName.replace('-', '_') %>
+  ENVIRONMENT_NAME: '{{ environment_name }}'
   APP_ENV: prod
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
-  SENTRY_ENVIRONMENT: '{{ environment_name }}'

--- a/generators/symfony/templates/base/config/packages/sentry.yaml
+++ b/generators/symfony/templates/base/config/packages/sentry.yaml
@@ -1,8 +1,8 @@
 parameters:
+    env(ENVIRONMENT_NAME): development
     env(SENTRY_DSN): ~
-    env(SENTRY_ENVIRONMENT): development
 
 sentry:
     dsn: '%env(SENTRY_DSN)%'
     options:
-        environment: '%env(SENTRY_ENVIRONMENT)%'
+        environment: '%env(ENVIRONMENT_NAME)%'


### PR DESCRIPTION
It's often usefull to have access to the environment name inside the application, by renaming it we make it usable for more things than juste the sentry setup.