### PR TITLE
Fix httpPath handling for CRA base packages

### DIFF
--- a/generators/create-react-app/templates/base/package.json.ejs
+++ b/generators/create-react-app/templates/base/package.json.ejs
@@ -2,6 +2,7 @@
   "name": "<%= packageName %>",
   "version": "0.1.0",
   "private": true,
+  "homepage": "<%= httpPath %>",
   "dependencies": {
     "@sentry/browser": "^6.1.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/generators/create-react-app/templates/nginx.conf.ejs
+++ b/generators/create-react-app/templates/nginx.conf.ejs
@@ -1,6 +1,4 @@
 location <%= httpPath %> {
-    rewrite <%= httpPath %>(.*) /$1 break;
-
     set $upstream "http://<%= packageName %>:3000";
 
     proxy_pass $upstream;

--- a/generators/react-admin/templates/base/package.json.ejs
+++ b/generators/react-admin/templates/base/package.json.ejs
@@ -2,6 +2,7 @@
   "name": "<%= packageName %>",
   "version": "0.1.0",
   "private": true,
+  "homepage": "<%= httpPath %>",
   "dependencies": {
     "@sentry/browser": "^6.1.0",
     "@testing-library/jest-dom": "^5.11.4",


### PR DESCRIPTION
Using URL rewriting result in incorrect path reference for asset loading. This PR replace it with handling of http path with homepage property.