### PR TITLE
Stop overriding vault pass if it exists

### DIFF
--- a/generators/root/index.ts
+++ b/generators/root/index.ts
@@ -50,15 +50,17 @@ class RootGenerator extends BaseGenerator {
     writing(): void {
         const { contactEmail, domain } = this.#answers as Prompt;
 
-        const vaultPass = cryptoRandomString({ length: 64, type: 'ascii-printable' });
-
         this.renderTemplate('base', '.', {
             contactEmail,
             domain,
             projectName: this.config.get('projectName'),
         });
 
-        this.writeDestination('ansible/vault_pass.txt', `${vaultPass}\n`);
+        if (!this.existsDestination('ansible/vault_pass.txt')) {
+            const vaultPass = cryptoRandomString({ length: 64, type: 'ascii-printable' });
+
+            this.writeDestination('ansible/vault_pass.txt', `${vaultPass}\n`);
+        }
     }
 
     async install(): Promise<void> {


### PR DESCRIPTION
Overriding the vault pass is a destructive operation since the file is not committed, this makes running the generator on an existing project safer.

This is usefull when re-running the generator to update a project or when testing developments on the generator.