### PR TITLE
Disable eslint plugin on CI build

### DIFF
--- a/generators/create-react-app/templates/circleci.yaml.ejs
+++ b/generators/create-react-app/templates/circleci.yaml.ejs
@@ -35,6 +35,7 @@ jobs:
       - run:
           command: yarn build
           environment:
+            DISABLE_ESLINT_PLUGIN: true
             NODE_ENV: production
       - persist_to_workspace:
           root: ~/project


### PR DESCRIPTION
Since we already do a lint in a previous step, the plugin is redundant.