### PR TITLE
Disable eslint plugin in CRA generator

### DIFF
--- a/generators/create-react-app/templates/docker-compose.yaml.ejs
+++ b/generators/create-react-app/templates/docker-compose.yaml.ejs
@@ -5,6 +5,7 @@ services:
             args:
                 UID: ${UID:-1000}
         environment:
+            DISABLE_ESLINT_PLUGIN: 'true'
             WDS_SOCKET_PATH: <%= httpPath %>sockjs-node
         volumes:
             - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>


### PR DESCRIPTION
The reasoning is:
 - Most of the time, developers use editor plugins that does the job
 - It slows down compilation
 - When trying to fix bugs/create a feature it's often useful to rapidly test code without having to bother with code style
 - Since we check for CS in the CI anyway, we can be sure that code that doesn't respect the CS isn't merged