### PR TITLE
Fix Symfony with twig request proxy chain

### DIFF
--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -18,17 +18,20 @@ class SymfonyGenerator extends PackageGenerator<Options> {
     }
 
     writing(): void {
-        const { packageName, packagePath } = this.options;
+        const { packageName, packagePath, twig } = this.options;
 
         this.renderTemplate('base', packagePath);
 
-        this.renderTemplate('nginx.conf.ejs', `nginx/docker/packages/${packageName}.conf`);
+        this.renderTemplate(
+            twig ? 'nginx-twig.conf.ejs' : 'nginx.conf.ejs',
+            `nginx/docker/packages/${packageName}.conf`,
+        );
 
         this.configureDockerCompose('docker-compose.yaml.ejs');
 
         this.configureCircleCI('circleci.yaml.ejs');
 
-        if (this.options.twig) {
+        if (twig) {
             this.renderTemplate('base-twig', packagePath);
 
             this.configureDockerCompose('docker-compose-twig.yaml.ejs');
@@ -38,10 +41,10 @@ class SymfonyGenerator extends PackageGenerator<Options> {
 
         this.configureAnsible('ansible', {
             repositoryName: this.config.get('repositoryName'),
-            twig: this.options.twig,
+            twig,
         });
 
-        this.configureScripts('script', { twig: this.options.twig });
+        this.configureScripts('script', { twig });
     }
 }
 

--- a/generators/symfony/templates/base-twig/webpack.config.js.ejs
+++ b/generators/symfony/templates/base-twig/webpack.config.js.ejs
@@ -10,7 +10,7 @@ module.exports = {
     output: {
         path: `${__dirname}/public/assets/`,
         filename: '[chunkhash].js',
-        publicPath: '/assets/',
+        publicPath: '<%= httpPath %>assets/',
     },
     module: {
         strictExportPresence: true,
@@ -66,9 +66,10 @@ module.exports = {
         }),
     ],
     devServer: {
+        allowedHosts: 'all',
         static: false,
         proxy: {
-            '/': 'http://nginx',
+            '<%= httpPath %>': 'http://<%= packageName %>-nginx',
         },
     },
 };

--- a/generators/symfony/templates/docker-compose-twig.yaml.ejs
+++ b/generators/symfony/templates/docker-compose-twig.yaml.ejs
@@ -18,5 +18,3 @@ services:
             - <%= packageName %>-nginx
         volumes_from:
             - <%= packageName %>-php
-        ports:
-            - 8080:8080

--- a/generators/symfony/templates/nginx-twig.conf.ejs
+++ b/generators/symfony/templates/nginx-twig.conf.ejs
@@ -1,0 +1,14 @@
+location <%= httpPath %> {
+    set $upstream "http://<%= packageName %>-node:8080";
+
+    proxy_pass $upstream;
+}
+
+location <%= httpPath %>sockjs-node {
+    set $upstream "http://<%= packageName %>-node:8080";
+
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}


### PR DESCRIPTION
This would probably needs some refactoring to simplify the proxy chain (currently nginx -> webpack-dev-server -> nginx -> php-fmp) but at least it should fix the current problem.