### PR TITLE
Allow no migrations in Symfony update script

### DIFF
--- a/generators/symfony/templates/script/update.ejs
+++ b/generators/symfony/templates/script/update.ejs
@@ -1,3 +1,3 @@
 
 docker-compose up --detach postgres
-docker-compose run --rm --no-deps <%= packageName %>-php wait-for-it postgres:5432 -- ./bin/console doctrine:migrations:migrate --no-interaction
+docker-compose run --rm --no-deps <%= packageName %>-php wait-for-it postgres:5432 -- ./bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration


### PR DESCRIPTION
This fix running the script on a newly generated project.