### PR TITLE
Fix Symfony webpack dev server websocket

### DIFF
--- a/generators/symfony/templates/base-twig/webpack.config.js.ejs
+++ b/generators/symfony/templates/base-twig/webpack.config.js.ejs
@@ -71,5 +71,8 @@ module.exports = {
         proxy: {
             '<%= httpPath %>': 'http://<%= packageName %>-nginx',
         },
+        client: {
+            webSocketURL: 'auto://0.0.0.0:0<%= httpPath %>ws',
+        },
     },
 };

--- a/generators/symfony/templates/nginx-twig.conf.ejs
+++ b/generators/symfony/templates/nginx-twig.conf.ejs
@@ -4,7 +4,7 @@ location <%= httpPath %> {
     proxy_pass $upstream;
 }
 
-location <%= httpPath %>sockjs-node {
+location <%= httpPath %>ws {
     set $upstream "http://<%= packageName %>-node:8080";
 
     proxy_pass $upstream;


### PR DESCRIPTION
- replace old sockjs path with the new WDS default
- fix client config to use browser port instead of server port