### PR TITLE
Fix invalid variable names if name have multiple dashes

### DIFF
--- a/generators/create-react-app/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/create-react-app/templates/ansible/group_vars/all.yaml.ejs
@@ -1,3 +1,3 @@
-<%= packageName.replace('-', '_') %>_data:
+<%= varify(packageName) %>_data:
   environment-name: '{{ environment_name }}'
   sentry-dsn: ~ # TODO: Add your sentry DSN here

--- a/generators/create-react-app/templates/ansible/package/deployment.yaml.ejs
+++ b/generators/create-react-app/templates/ansible/package/deployment.yaml.ejs
@@ -13,7 +13,7 @@
     before_finalize:
       - >
         sed --in-place --expression='s#<div id="root"[^>]*>#<div id="root"
-        {%- for key, value in <%= packageName.replace('-', '_') %>_data|dictsort %} data-{{ key }}="{{ value }}"{% endfor -%}
+        {%- for key, value in <%= varify(packageName) %>_data|dictsort %} data-{{ key }}="{{ value }}"{% endfor -%}
         >#g' build/index.html
     job_name: <%= packageName %>-archive
     repository_name: <%= repositoryName %>

--- a/generators/express/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/express/templates/ansible/group_vars/all.yaml.ejs
@@ -1,7 +1,7 @@
-<%= packageName.replace('-', '_') %>_port: 4000
-<%= packageName.replace('-', '_') %>_env:
-  DATABASE_URL: postgres://<%= packageName.replace('-', '_') %>:{{ database_<%= packageName.replace('-', '_') %>_password }}@{{ database_host }}/<%= packageName.replace('-', '_') %>
+<%= varify(packageName) %>_port: 4000
+<%= varify(packageName) %>_env:
+  DATABASE_URL: postgres://<%= varify(packageName) %>:{{ database_<%= varify(packageName) %>_password }}@{{ database_host }}/<%= varify(packageName) %>
   ENVIRONMENT_NAME: '{{ environment_name }}'
   NODE_ENV: production
-  PORT: '{{ <%= packageName.replace('-', '_') %>_port }}'
+  PORT: '{{ <%= varify(packageName) %>_port }}'
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here

--- a/generators/express/templates/ansible/package/deployment.yaml.ejs
+++ b/generators/express/templates/ansible/package/deployment.yaml.ejs
@@ -7,7 +7,7 @@
   delegate_to: localhost
 - import_role:
     name: deploy
-  environment: '{{ <%= packageName.replace('-', '_') %>_env }}'
+  environment: '{{ <%= varify(packageName) %>_env }}'
   vars:
     path: /home/<%= packageName %>
     artifact_path: <%= packageName %>.tar.gz

--- a/generators/express/templates/ansible/package/nginx.conf.j2.ejs
+++ b/generators/express/templates/ansible/package/nginx.conf.j2.ejs
@@ -1,7 +1,7 @@
 location <%= httpPath %> {
     client_max_body_size 25M;
 
-    proxy_pass http://localhost:{{ <%= packageName.replace('-', '_') %>_port }}/;
+    proxy_pass http://localhost:{{ <%= varify(packageName) %>_port }}/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/generators/express/templates/ansible/package/provision.yaml.ejs
+++ b/generators/express/templates/ansible/package/provision.yaml.ejs
@@ -28,4 +28,4 @@
     service: <%= packageName %>
     user: <%= packageName %>
     group: <%= packageName %>
-    env: '{{ <%= packageName.replace('-', '_') %>_env }}'
+    env: '{{ <%= varify(packageName) %>_env }}'

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -8,4 +8,4 @@ services:
             - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
             COOKIE_SECRET: development-secret
-            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packagePath) %>"
+            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packageName) %>"

--- a/generators/express/templates/docker-compose.yaml.ejs
+++ b/generators/express/templates/docker-compose.yaml.ejs
@@ -8,4 +8,4 @@ services:
             - ./<%= packagePath %>:/usr/src/project/<%= packagePath %>
         environment:
             COOKIE_SECRET: development-secret
-            DATABASE_URL: "postgresql://user:password@postgres/<%= packagePath.replace('-', '_') %>"
+            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packagePath) %>"

--- a/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/next-js/templates/ansible/group_vars/all.yaml.ejs
@@ -1,5 +1,5 @@
-<%= packageName.replace('-', '_') %>_port: 3000
-<%= packageName.replace('-', '_') %>_env:
+<%= varify(packageName) %>_port: 3000
+<%= varify(packageName) %>_env:
   ENVIRONMENT_NAME: '{{ environment_name }}'
   NODE_ENV: production
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here

--- a/generators/next-js/templates/ansible/package/deployment.yaml.ejs
+++ b/generators/next-js/templates/ansible/package/deployment.yaml.ejs
@@ -7,7 +7,7 @@
   delegate_to: localhost
 - import_role:
     name: deploy
-  environment: '{{ <%= packageName.replace('-', '_') %>_env }}'
+  environment: '{{ <%= varify(packageName) %>_env }}'
   vars:
     path: /home/<%= packageName %>
     artifact_path: <%= packageName %>.tar.gz

--- a/generators/next-js/templates/ansible/package/nginx.conf.j2.ejs
+++ b/generators/next-js/templates/ansible/package/nginx.conf.j2.ejs
@@ -1,7 +1,7 @@
 location <%= httpPath %> {
     client_max_body_size 25M;
 
-    proxy_pass http://localhost:{{ <%= packageName.replace('-', '_') %>_port }}/;
+    proxy_pass http://localhost:{{ <%= varify(packageName) %>_port }}/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/generators/next-js/templates/ansible/package/provision.yaml.ejs
+++ b/generators/next-js/templates/ansible/package/provision.yaml.ejs
@@ -24,9 +24,9 @@
     name: service
   vars:
     working_directory: /home/<%= packageName %>/current
-    command: /home/<%= packageName %>/current/node_modules/.bin/next start --port {{ <%= packageName.replace('-', '_') %>_port }}
+    command: /home/<%= packageName %>/current/node_modules/.bin/next start --port {{ <%= varify(packageName) %>_port }}
     description: <%= packageName %>
     service: <%= packageName %>
     user: <%= packageName %>
     group: <%= packageName %>
-    env: '{{ <%= packageName.replace('-', '_') %>_env }}'
+    env: '{{ <%= varify(packageName) %>_env }}'

--- a/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
+++ b/generators/symfony/templates/ansible/group_vars/all.yaml.ejs
@@ -1,7 +1,7 @@
-<%= packageName.replace('-', '_') %>_env:
-  DATABASE_URL: postgresql://<%= packageName.replace('-', '_') %>:{{ database_<%= packageName.replace('-', '_') %>_password }}@{{ database_host }}/<%= packageName.replace('-', '_') %>
+<%= varify(packageName) %>_env:
+  DATABASE_URL: postgresql://<%= varify(packageName) %>:{{ database_<%= varify(packageName) %>_password }}@{{ database_host }}/<%= varify(packageName) %>
   ENVIRONMENT_NAME: '{{ environment_name }}'
   APP_ENV: prod
-  APP_SECRET: '{{ <%= packageName.replace('-', '_') %>_secret }}'
+  APP_SECRET: '{{ <%= varify(packageName) %>_secret }}'
   SENTRY_DSN: ~ # TODO: Add your sentry DSN here
-<%= packageName.replace('-', '_') %>_php_version: 8.0
+<%= varify(packageName) %>_php_version: 8.0

--- a/generators/symfony/templates/ansible/group_vars/staging.yaml.ejs
+++ b/generators/symfony/templates/ansible/group_vars/staging.yaml.ejs
@@ -1,2 +1,2 @@
-<%= packageName.replace('-', '_') %>_secret: !vault |
+<%= varify(packageName) %>_secret: !vault |
 <%= indent(encrypt(secret), 2) %>

--- a/generators/symfony/templates/ansible/package/deployment.yaml.ejs
+++ b/generators/symfony/templates/ansible/package/deployment.yaml.ejs
@@ -14,4 +14,4 @@
       - ./bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
     job_name: <%= packageName %>-build
     repository_name: <%= repositoryName %>
-  environment: '{{ <%= packageName.replace('-', '_') %>_env }}'
+  environment: '{{ <%= varify(packageName) %>_env }}'

--- a/generators/symfony/templates/ansible/package/nginx.conf.j2.ejs
+++ b/generators/symfony/templates/ansible/package/nginx.conf.j2.ejs
@@ -6,7 +6,7 @@ location <%= httpPath %> {
     try_files $uri /index.php$is_args$args;
 
     location ~ ^/index\.php(/|$) {
-        fastcgi_pass unix:/run/php/<%= packageName %>-{{ <%= packageName.replace('-', '_') %>_php_version }}.sock;
+        fastcgi_pass unix:/run/php/<%= packageName %>-{{ <%= varify(packageName) %>_php_version }}.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;

--- a/generators/symfony/templates/ansible/package/provision.yaml.ejs
+++ b/generators/symfony/templates/ansible/package/provision.yaml.ejs
@@ -20,10 +20,10 @@
     name: php_fpm_pool
   vars:
     pool: <%= packageName %>
-    version: '{{ <%= packageName.replace('-', '_') %>_php_version }}'
+    version: '{{ <%= varify(packageName) %>_php_version }}'
     user: <%= packageName %>
     group: <%= packageName %>
-    env: '{{ <%= packageName.replace('-', '_') %>_env }}'
+    env: '{{ <%= varify(packageName) %>_env }}'
     extensions:
       - intl
       - mbstring

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -16,7 +16,7 @@ services:
         environment:
             APP_ENV: dev
             APP_SECRET: dev_secret
-            DATABASE_URL: "postgresql://user:password@postgres/<%= packagePath.replace('-', '_') %>"
+            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packagePath) %>"
         depends_on:
             - postgres
         volumes:

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -16,7 +16,7 @@ services:
         environment:
             APP_ENV: dev
             APP_SECRET: dev_secret
-            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packagePath) %>"
+            DATABASE_URL: "postgresql://user:password@postgres/<%= varify(packageName) %>"
         depends_on:
             - postgres
         volumes:

--- a/generators/utils/database/index.ts
+++ b/generators/utils/database/index.ts
@@ -2,6 +2,7 @@ import cryptoRandomString from 'crypto-random-string';
 import { GeneratorOptions } from 'yeoman-generator';
 import { createEncrypt } from '../../../utils/ansible';
 import BaseGenerator from '../../../utils/BaseGenerator';
+import varify from '../../../utils/varify';
 
 interface DatabaseUtilGeneratorOptions extends GeneratorOptions {
     packageName: string;
@@ -34,15 +35,13 @@ class DatabaseUtilGenerator extends BaseGenerator<DatabaseUtilGeneratorOptions> 
             'terraform/common/database/outputs.tf',
             'terraform/production/outputs.tf',
         ].every(this.existsDestination.bind(this))) {
-            const packageVariable = packageName.replace('-', '_');
-
             this.appendTemplate('database.tf.ejs', 'terraform/common/database/main.tf', { packageName });
             this.appendTemplate('outputs.tf.ejs', 'terraform/common/database/outputs.tf', { packageName });
             this.writeDestination(
                 'terraform/production/outputs.tf',
                 this.readDestination('terraform/production/outputs.tf').replace(
                     /(output "vars" {\n {4}value = {.*?)(\n {4}})/s,
-                    `$1\n        database_${packageVariable}_password = module.database.${packageVariable}_password$2`,
+                    `$1\n        database_${varify(packageName)}_password = module.database.${varify(packageName)}_password$2`,
                 ),
             );
         } else {

--- a/generators/utils/database/templates/database.sql.ejs
+++ b/generators/utils/database/templates/database.sql.ejs
@@ -1,1 +1,1 @@
-CREATE DATABASE <%= packageName.replace('-', '_') %> WITH OWNER 'user';
+CREATE DATABASE <%= varify(packageName) %> WITH OWNER 'user';

--- a/generators/utils/database/templates/database.tf.ejs
+++ b/generators/utils/database/templates/database.tf.ejs
@@ -1,22 +1,22 @@
 
-resource "random_password" "<%= packageName.replace('-', '_') %>" {
+resource "random_password" "<%= varify(packageName) %>" {
     length = 32
 }
 
-resource "scaleway_rdb_user" "<%= packageName.replace('-', '_') %>" {
+resource "scaleway_rdb_user" "<%= varify(packageName) %>" {
     instance_id = scaleway_rdb_instance.database.id
-    name        = "<%= packageName.replace('-', '_') %>"
-    password    = random_password.<%= packageName.replace('-', '_') %>.result
+    name        = "<%= varify(packageName) %>"
+    password    = random_password.<%= varify(packageName) %>.result
 }
 
-resource "scaleway_rdb_database" "<%= packageName.replace('-', '_') %>" {
+resource "scaleway_rdb_database" "<%= varify(packageName) %>" {
     instance_id = scaleway_rdb_instance.database.id
-    name        = "<%= packageName.replace('-', '_') %>"
+    name        = "<%= varify(packageName) %>"
 }
 
-resource "scaleway_rdb_privilege" "<%= packageName.replace('-', '_') %>" {
+resource "scaleway_rdb_privilege" "<%= varify(packageName) %>" {
     instance_id   = scaleway_rdb_instance.database.id
-    user_name     = scaleway_rdb_user.<%= packageName.replace('-', '_') %>.name
-    database_name = scaleway_rdb_database.<%= packageName.replace('-', '_') %>.name
+    user_name     = scaleway_rdb_user.<%= varify(packageName) %>.name
+    database_name = scaleway_rdb_database.<%= varify(packageName) %>.name
     permission    = "all"
 }

--- a/generators/utils/database/templates/outputs.tf.ejs
+++ b/generators/utils/database/templates/outputs.tf.ejs
@@ -1,4 +1,4 @@
 
-output "<%= packageName.replace('-', '_') %>_password" {
-    value = random_password.<%= packageName.replace('-', '_') %>.result
+output "<%= varify(packageName) %>_password" {
+    value = random_password.<%= varify(packageName) %>.result
 }

--- a/generators/utils/database/templates/provision.yaml.ejs
+++ b/generators/utils/database/templates/provision.yaml.ejs
@@ -2,9 +2,9 @@
     name: postgresql
   vars:
     dbs:
-      <%= packageName.replace('-', '_') %>:
-        owner: <%= packageName.replace('-', '_') %>
+      <%= varify(packageName) %>:
+        owner: <%= varify(packageName) %>
     users:
-      <%= packageName.replace('-', '_') %>:
-        password: '{{ database_<%= packageName.replace('-', '_') %>_password }}'
+      <%= varify(packageName) %>:
+        password: '{{ database_<%= varify(packageName) %>_password }}'
   when: database_host == "localhost"

--- a/generators/utils/database/templates/staging.yaml.ejs
+++ b/generators/utils/database/templates/staging.yaml.ejs
@@ -1,2 +1,2 @@
-database_<%= packageName.replace('-', '_') %>_password: !vault |
+database_<%= varify(packageName) %>_password: !vault |
 <%= indent(encrypt(databasePassword), 2) %>

--- a/utils/BaseGenerator.ts
+++ b/utils/BaseGenerator.ts
@@ -5,6 +5,7 @@ import { CopyOptions } from 'mem-fs-editor';
 import Generator, { GeneratorOptions } from 'yeoman-generator';
 import { rootDomain, subdomain } from './domain';
 import indent from './indent';
+import varify from './varify';
 
 const processDestinationPath = (path: string): string => path
     .replace(/\.ejs$/, '')
@@ -41,6 +42,7 @@ class BaseGenerator<T extends GeneratorOptions = GeneratorOptions> extends Gener
             indent,
             rootDomain,
             subdomain,
+            varify,
 
             // Common variables
             projectName,

--- a/utils/varify.test.ts
+++ b/utils/varify.test.ts
@@ -1,0 +1,9 @@
+import varify from './varify';
+
+test('It replaces dashes with underscores', () => {
+    expect(varify('some-name')).toBe('some_name');
+});
+
+test('It replaces multiple dashes with underscores', () => {
+    expect(varify('some-other-name')).toBe('some_other_name');
+});

--- a/utils/varify.ts
+++ b/utils/varify.ts
@@ -1,0 +1,6 @@
+/**
+ * Transform a name into a valid variable name.
+ */
+const varify = (name: string) => name.replace(/-/g, '_');
+
+export default varify;


### PR DESCRIPTION
Extract logic transforming project and package names into variables names and fix a bug not transforming name correctly when they contain multiple dashes.