### PR TITLE
Add a test to the generated express project

### DIFF
--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -39,6 +39,10 @@ describe('When running the generator', () => {
         await run('test', 'yarn', ['lint']);
     });
 
+    test('It generates a project which correctly pass tests', async () => {
+        await run('test', 'yarn', ['test']);
+    });
+
     test('It generates a docker-compose.yaml with the right fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
         expect(all.version).toBeDefined();

--- a/generators/express/templates/base/.eslintrc.json
+++ b/generators/express/templates/base/.eslintrc.json
@@ -6,5 +6,13 @@
     },
     "env": {
         "node": true
-    }
+    },
+    "overrides": [
+        {
+            "files": ["*.test.ts"],
+            "env": {
+                "jest": true
+            }
+        }
+    ]
 }

--- a/generators/express/templates/base/src/domain/User.test.ts
+++ b/generators/express/templates/base/src/domain/User.test.ts
@@ -1,0 +1,17 @@
+import { User } from './User';
+
+test('checkPassword return true on valid password', async () => {
+    const user = new User('test@example.com');
+
+    await user.updatePassword('Pas$w0rd');
+
+    expect(await user.checkPassword('Pas$w0rd')).toBe(true);
+});
+
+test('checkPassword return false on valid password', async () => {
+    const user = new User('test@example.com');
+
+    await user.updatePassword('Pas$w0rd');
+
+    expect(await user.checkPassword('Wrong')).toBe(false);
+});


### PR DESCRIPTION
This adds an example and prevent a newly generated project to have a failing CI due to jest erroring on missing tests.