### PR TITLE
Update Scaleway provider version

### DIFF
--- a/generators/root/templates/deployment/ansible/terraform/common/server/main.tf.ejs
+++ b/generators/root/templates/deployment/ansible/terraform/common/server/main.tf.ejs
@@ -2,7 +2,7 @@ terraform {
     required_providers {
         scaleway = {
             source  = "scaleway/scaleway"
-            version = ">= 2.0.0"
+            version = ">= 2.2.0"
         }
     }
 }


### PR DESCRIPTION
En version 2.0 du provider scaleway, la resource `scaleway_domain_record` n'existe pas.