### PR TITLE
Run generators tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build": "./scripts/build.mjs",
     "lint": "eslint --ext ts generators utils",
     "test": "yarn test:utils && yarn test:generators",
-    "test:generators": "jest --runInBand --testTimeout 300000 generators",
+    "test:generators": "jest --testTimeout 300000 generators",
     "test:utils": "jest utils",
     "test:utils:coverage": "yarn test:utils --coverage --collectCoverageFrom 'utils/**/*'"
   }


### PR DESCRIPTION
We disabled running test in parallel before because of conflicts with yarn cache but now that we run yarn inside docker it shouldn't happen anymore.