### PR TITLE
Don't tag docker image when not pushing

### DIFF
--- a/generators/create-react-app/templates/circleci.yaml.ejs
+++ b/generators/create-react-app/templates/circleci.yaml.ejs
@@ -100,7 +100,6 @@ jobs:
       - checkout
       - docker/build:
           image: <%= projectName %>-<%= packageName %>
-          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'

--- a/generators/express/templates/circleci.yaml.ejs
+++ b/generators/express/templates/circleci.yaml.ejs
@@ -115,7 +115,6 @@ jobs:
       - checkout
       - docker/build:
           image: <%= projectName %>-<%= packageName %>
-          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'

--- a/generators/next-js/templates/circleci.yaml.ejs
+++ b/generators/next-js/templates/circleci.yaml.ejs
@@ -90,7 +90,6 @@ jobs:
       - checkout
       - docker/build:
           image: <%= projectName %>-<%= packageName %>
-          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'

--- a/generators/symfony/templates/circleci.yaml.ejs
+++ b/generators/symfony/templates/circleci.yaml.ejs
@@ -215,13 +215,11 @@ jobs:
       - checkout
       - docker/build:
           image: <%= projectName %>-<%= packageName %>-php
-          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--target=php --build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
       - docker/build:
           image: <%= projectName %>-<%= packageName %>-nginx
-          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--target=nginx --build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'


### PR DESCRIPTION
When not pushing, the docker tag doesn't matter since we only build to test if the build pass correctly. This should fix problems with branch names that aren't valid docker tags.

This should fix https://github.com/thetribeio/generator-project/issues/1040