### PR TITLE
Allow selecting multiple frontends in app generator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,8 @@
         "project": "./tsconfig.json"
     },
     "rules": {
+        "@typescript-eslint/explicit-function-return-type": "error",
+        "consistent-return": "off",
         "import/no-extraneous-dependencies": ["error", {
            "devDependencies": [
                 "**/__tests__/**",

--- a/generators/app/index.test.ts
+++ b/generators/app/index.test.ts
@@ -12,7 +12,7 @@ describe('When running the generator with Create React App', () => {
             .withPrompts({
                 backend: 'express',
                 contactEmail: 'test@example.com',
-                frontend: 'create-react-app',
+                type: 'create-react-app',
             });
 
         root = result.cwd;
@@ -50,7 +50,11 @@ describe('When running the generator with Next.js', () => {
 
     beforeAll(async () => {
         const result = await helpers.run(__dirname)
-            .withPrompts({ backend: 'express', contactEmail: 'test@example.com', frontend: 'next-js' });
+            .withPrompts({
+                backend: 'express',
+                contactEmail: 'test@example.com',
+                type: 'next-js',
+            });
 
         root = result.cwd;
     });
@@ -90,7 +94,8 @@ describe('When running the generator with Symfony', () => {
             .withPrompts({
                 backend: 'symfony',
                 contactEmail: 'test@example.com',
-                frontend: 'twig',
+                add: false,
+                twig: true,
             });
 
         root = result.cwd;
@@ -119,8 +124,7 @@ describe('When running the generator with Flutter', () => {
                 projectName: 'my_project',
                 backend: 'express',
                 contactEmail: 'test@example.com',
-                frontend: 'next-js',
-                mobile: 'flutter',
+                type: 'flutter',
                 applicationPrefix: 'com.example',
                 applicationDisplayName: 'My Project',
             });
@@ -155,8 +159,7 @@ describe('When running the generator with React-Native', () => {
                 projectName: 'my_project',
                 backend: 'express',
                 contactEmail: 'test@example.com',
-                frontend: 'next-js',
-                mobile: 'react-native',
+                type: 'react-native',
                 applicationPrefix: 'com.example',
                 applicationDisplayName: 'My Project',
             });

--- a/generators/symfony/index.test.ts
+++ b/generators/symfony/index.test.ts
@@ -16,7 +16,7 @@ describe('When running the generator', () => {
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ twig: true })
+            .withPrompts({ twig: true })
             .withArguments(['test']);
 
         await execa(path.resolve(root, 'script', 'bootstrap'));
@@ -127,7 +127,7 @@ describe('When running the generator with twig frontend and kubernetes deploymen
 
         await helpers.run(__dirname)
             .cd(root)
-            .withOptions({ twig: true })
+            .withPrompts({ twig: true })
             .withArguments(['test']);
     });
 

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -1,29 +1,38 @@
 import cryptoRandomString from 'crypto-random-string';
+import { Question } from 'yeoman-generator';
 import { createEncrypt } from '../../utils/ansible';
-import PackageGenerator, { PackageGeneratorOptions } from '../../utils/PackageGenerator';
+import PackageGenerator from '../../utils/PackageGenerator';
 import varName from '../../utils/varName';
 import { DeploymentChoice } from '../root';
 
-interface Options extends PackageGeneratorOptions {
-    twig: boolean;
+interface Prompt {
+    twig: boolean,
 }
 
-class SymfonyGenerator extends PackageGenerator<Options> {
-    constructor(args: string | string[], opts: Options) {
-        super(args, opts);
+const prompt: Question<Prompt>[] = [
+    {
+        type: 'confirm',
+        name: 'twig',
+        message: 'Would you like to add twig to the Symfony backend?',
+        default: false,
+    },
+];
 
-        this.option('twig', { type: Boolean });
-    }
-
+class SymfonyGenerator extends PackageGenerator {
     initializing(): void {
         const { packageName } = this.options;
 
         this.composeWith(require.resolve('../utils/database'), [packageName]);
     }
 
+    async prompting(): Promise<void> {
+        await this.promptConfig<Prompt>(prompt);
+    }
+
     writing(): void {
         const projectName = this.config.get('projectName');
-        const { packageName, packagePath, twig } = this.options;
+        const twig = this.config.get('twig');
+        const { packageName, packagePath } = this.options;
 
         this.renderTemplate('base', packagePath);
 

--- a/generators/utils/database/index.ts
+++ b/generators/utils/database/index.ts
@@ -31,7 +31,7 @@ class DatabaseUtilGenerator extends BaseGenerator<DatabaseUtilGeneratorOptions> 
         }
     }
 
-    #writeAnsibleDeployment() {
+    #writeAnsibleDeployment(): void {
         const { packageName } = this.options;
 
         this.appendTemplate('deployment/ansible/staging.yaml.ejs', 'ansible/group_vars/staging.yaml', {

--- a/utils/ansible/vault.ts
+++ b/utils/ansible/vault.ts
@@ -6,7 +6,7 @@ const AES256 = 'AES256';
 const CIPHER = 'aes-256-ctr';
 const DIGEST = 'sha256';
 
-const deriveKey = (salt: Buffer, password: string) => {
+const deriveKey = (salt: Buffer, password: string): { key: Buffer, hmacKey: Buffer, iv: Buffer } => {
     const derivedKey = crypto.pbkdf2Sync(password, salt, 10000, 80, DIGEST);
     const key = derivedKey.slice(0, 32);
     const hmacKey = derivedKey.slice(32, 64);

--- a/utils/validation/validateFrontendName.test.ts
+++ b/utils/validation/validateFrontendName.test.ts
@@ -1,0 +1,29 @@
+import validateFrontendName from './validateFrontendName';
+
+test('Frontend can not be named "backend"', () => {
+    expect(validateFrontendName([])('backend'))
+        .toBe('A frontend can not be named backend');
+});
+
+test('Frontend can not be named the same as an already existing frontend', () => {
+    expect(validateFrontendName(['frontend'])('frontend'))
+        .toBe('There is already one frontend called "frontend"');
+});
+
+test('Frontend name with a space is not valid', () => {
+    expect(validateFrontendName([])('test project'))
+        .toBe('Frontend name can only contains lowercase alphanumerical characters and dashes');
+});
+
+test('Frontend name with uppercase characters is not valid', () => {
+    expect(validateFrontendName([])('TEST'))
+        .toBe('Frontend name can only contains lowercase alphanumerical characters and dashes');
+});
+
+test('Frontend name starting with a number is not valid', () => {
+    expect(validateFrontendName([])('123test')).toBe('Frontend name must start with an alphabetical character');
+});
+
+test('Valid frontend name', () => {
+    expect(validateFrontendName([])('test-001-project')).toBe(true);
+});

--- a/utils/validation/validateFrontendName.ts
+++ b/utils/validation/validateFrontendName.ts
@@ -1,0 +1,23 @@
+import { Validator } from './types';
+
+const validateFrontendName = (frontendNames: string[]): Validator => (value) => {
+    if (value === 'backend') {
+        return 'A frontend can not be named backend';
+    }
+
+    if (frontendNames.includes(value)) {
+        return `There is already one frontend called "${value}"`;
+    }
+
+    if (!/^[a-z0-9-]*$/.test(value)) {
+        return 'Frontend name can only contains lowercase alphanumerical characters and dashes';
+    }
+
+    if (!/^[a-z]/.test(value)) {
+        return 'Frontend name must start with an alphabetical character';
+    }
+
+    return true;
+};
+
+export default validateFrontendName;

--- a/utils/varName.ts
+++ b/utils/varName.ts
@@ -1,6 +1,6 @@
 /**
  * Transform a name into a valid variable name.
  */
-const varName = (name: string) => name.replace(/-/g, '_');
+const varName = (name: string): string => name.replace(/-/g, '_');
 
 export default varName;


### PR DESCRIPTION
This is my take on https://github.com/thetribeio/generator-project/issues/938#issuecomment-1042991062.

## This replaces https://github.com/thetribeio/generator-project/pull/979 with the following additional changes

### Twig is no longer a frontend but an option in the Symfony generator

Since we can create projects without a separated frontend, we don't lose the possibility of a Symfony/Twig project and it removes a lot of special handling in the app generator code (and prevent having to block the developer to add multiple twig frontends).

This slightly worsen the DX but this could be solved by moving the question before the frontend one (but it would require hacking around the order Yeoman ask questions).

### Frontend are required to be named by the user

To allow multiple frontends of the same type without resorting to ugly indexes in the names, we require the user to name each frontend, but provide sensible defaults to make it less tedious.

### The saving (and reloading) of the list of frontends to the `.yo-rc.json` file works properly

This is done by abandoning the usage of the `promptConfig` method and using a custom saving and reloading logic.

## Remaining

- Handle conflicting HTTP paths when adding multiple web frontends.
- The way choices are saved into the config will break saving an reloading for frontends of the same type (I think only the mobile generators are in this case).