### PR TITLE
Use document_root instead of realpath_root

### DIFF
--- a/generators/symfony/templates/deployment/kubernetes/docker/default.conf.ejs
+++ b/generators/symfony/templates/deployment/kubernetes/docker/default.conf.ejs
@@ -10,8 +10,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
 
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 
         internal;
     }


### PR DESCRIPTION
Use document_root instead of realpath_root to speed up nginx handling (since it doesn't have to resolve symlinks) and prevent bugs when the path doesn't exists in the nginx container.

This is possible because docker base deployments doesn't involve any symlink.