### PR TITLE
Use HTTPS URL for roles submodule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push: ~
-  
+
 permissions:
   contents: read
 
@@ -56,9 +56,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.2
-      - run: |
-          git config --global init.defaultBranch main
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - run: git config --global init.defaultBranch main
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:

--- a/generators/root/templates/deployment/ansible/.gitmodules
+++ b/generators/root/templates/deployment/ansible/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ansible/roles-lib"]
 	path = ansible/roles-lib
-	url = git@github.com:thetribeio/ansible-roles.git
+	url = https://github.com/thetribeio/ansible-roles.git


### PR DESCRIPTION
Since the repository is public, using HTTPS is less error prone since HTTPS can be annonymous contrary to SSH which is always authenticated.