### PR TITLE
Update .gitignore

### DIFF
--- a/generators/express/templates/base/.gitignore
+++ b/generators/express/templates/base/.gitignore
@@ -1,3 +1,5 @@
 /coverage/
 /dist/
 /node_modules/
+/yarn-debug.log
+/yarn-error.log


### PR DESCRIPTION
yarn-error and yarn-debug are used locally to debug failing yarn commands. there is no need to version those files