### PR TITLE
Remove version key from docker-compose config file

### DIFF
--- a/generators/express/index.test.ts
+++ b/generators/express/index.test.ts
@@ -45,7 +45,7 @@ describe('When running the generator', () => {
 
     test('It generates a docker-compose.yaml with the right fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
-        expect(all.version).toBeDefined();
+        expect(all.version).toBeUndefined();
         expect(all.services[packageName]).toBeDefined();
     });
 

--- a/generators/next-js/index.test.ts
+++ b/generators/next-js/index.test.ts
@@ -41,7 +41,7 @@ describe('When running the generator', () => {
 
     test('It generates a docker-compose.yaml with the right fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
-        expect(all.version).toBeDefined();
+        expect(all.version).toBeUndefined();
         expect(all.services[packageName]).toBeDefined();
     });
 });

--- a/generators/react/index.test.ts
+++ b/generators/react/index.test.ts
@@ -42,10 +42,10 @@ describe('When running the generator', () => {
         await run('test', 'yarn', ['test', '--run']);
     });
 
-    test('It generates a docker-compose.yaml with a version fields', async () => {
+    test('It generates a docker-compose.yaml without a version fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
 
-        expect(all.version).toBeDefined();
+        expect(all.version).toBeUndefined();
     });
 
     test('It extends the ansible configuration', async () => {

--- a/generators/root/templates/base/docker-compose.yaml
+++ b/generators/root/templates/base/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
     nginx:
         build: ./nginx/docker

--- a/generators/symfony/index.test.ts
+++ b/generators/symfony/index.test.ts
@@ -45,10 +45,10 @@ describe('When running the generator', () => {
         await run('test-php', 'bin/console', ['lint:container']);
     });
 
-    test('It generates a docker-compose.yaml with a version fields', async () => {
+    test('It generates a docker-compose.yaml without a version fields', async () => {
         const all = YAML.parse(await fs.promises.readFile(path.resolve(root, 'docker-compose.yaml'), 'utf8'));
 
-        expect(all.version).toBeDefined();
+        expect(all.version).toBeUndefined();
     });
 
     test('It extends the ansible configuration', async () => {

--- a/generators/symfony/templates/docker-compose-twig.yaml.ejs
+++ b/generators/symfony/templates/docker-compose-twig.yaml.ejs
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
     <%= packageName %>-node:
         build:

--- a/generators/symfony/templates/docker-compose.yaml.ejs
+++ b/generators/symfony/templates/docker-compose.yaml.ejs
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
     <%= packageName %>-nginx:
         build: <%= packagePath %>/docker/nginx


### PR DESCRIPTION
It's now recommended to not specify the file version since it's ignored by more recent versions of Docker Compose.