### PR TITLE
Use slash as separator for image names

### DIFF
--- a/generators/express/index.ts
+++ b/generators/express/index.ts
@@ -70,7 +70,7 @@ class ExpressGenerator extends PackageGenerator {
                 this.appendDestination('modules/deployment/release.tf', indent`
 
                     data "docker_registry_image" "${packageVar}" {
-                        name = "\${var.registry}/${projectName}-${packageName}:\${var.${packageVar}_image_tag}"
+                        name = "\${var.registry}/${projectName}/${packageName}:\${var.${packageVar}_image_tag}"
                     }
                 `);
 

--- a/generators/express/templates/circleci.yaml.ejs
+++ b/generators/express/templates/circleci.yaml.ejs
@@ -111,7 +111,7 @@ jobs:
           version: 20.10.11
       - checkout
       - docker/build:
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
@@ -123,7 +123,7 @@ jobs:
       - checkout
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
@@ -132,7 +132,7 @@ jobs:
           registry: $DOCKER_REGISTRY
       - docker/push:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
 <% } %>
 

--- a/generators/express/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
+++ b/generators/express/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
@@ -1,5 +1,5 @@
 {{- define "<%= projectName %>.<%= packageName %>.image" }}
-{{- .Values.registry }}/<%= projectName %>-<%= packageName %>
+{{- .Values.registry }}/<%= projectName %>/<%= packageName %>
 {{- if .Values.<%= varName(packageName) %>.image.digest -}}
 @{{ .Values.<%= varName(packageName) %>.image.digest }}
 {{- else -}}

--- a/generators/next-js/index.ts
+++ b/generators/next-js/index.ts
@@ -57,7 +57,7 @@ class NextJSGenerator extends PackageGenerator {
                 this.appendDestination('modules/deployment/release.tf', indent`
 
                     data "docker_registry_image" "${packageVar}" {
-                        name = "\${var.registry}/${projectName}-${packageName}:\${var.${packageVar}_image_tag}"
+                        name = "\${var.registry}/${projectName}/${packageName}:\${var.${packageVar}_image_tag}"
                     }
                 `);
 

--- a/generators/next-js/templates/circleci.yaml.ejs
+++ b/generators/next-js/templates/circleci.yaml.ejs
@@ -87,7 +87,7 @@ jobs:
           version: 20.10.11
       - checkout
       - docker/build:
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
@@ -99,7 +99,7 @@ jobs:
       - checkout
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
@@ -108,7 +108,7 @@ jobs:
           registry: $DOCKER_REGISTRY
       - docker/push:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
 <% } %>
 

--- a/generators/next-js/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
+++ b/generators/next-js/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
@@ -1,5 +1,5 @@
 {{- define "<%= projectName %>.<%= packageName %>.image" }}
-{{- .Values.registry }}/<%= projectName %>-<%= packageName %>
+{{- .Values.registry }}/<%= projectName %>/<%= packageName %>
 {{- if .Values.<%= varName(packageName) %>.image.digest -}}
 @{{ .Values.<%= varName(packageName) %>.image.digest }}
 {{- else -}}

--- a/generators/react/index.ts
+++ b/generators/react/index.ts
@@ -61,7 +61,7 @@ class CreateReactAppGenerator extends PackageGenerator {
                 this.appendDestination('modules/deployment/release.tf', indent`
 
                     data "docker_registry_image" "${packageVar}" {
-                        name = "\${var.registry}/${projectName}-${packageName}:\${var.${packageVar}_image_tag}"
+                        name = "\${var.registry}/${projectName}/${packageName}:\${var.${packageVar}_image_tag}"
                     }
                 `);
 

--- a/generators/react/templates/circleci.yaml.ejs
+++ b/generators/react/templates/circleci.yaml.ejs
@@ -98,7 +98,7 @@ jobs:
           version: 20.10.11
       - checkout
       - docker/build:
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
@@ -110,15 +110,15 @@ jobs:
       - checkout
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
-          tag: << pipeline.git.branch >>-sentry
+          image: <%= projectName %>/<%= packageName %>/sentry
+          tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>") --target sentry'
@@ -126,12 +126,12 @@ jobs:
           registry: $DOCKER_REGISTRY
       - docker/push:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>
+          image: <%= projectName %>/<%= packageName %>
           tag: << pipeline.git.branch >>
       - run:
           name: Publish source maps to sentry
           command: |
-            IMAGE="$DOCKER_REGISTRY/<%= projectName %>-<%= packageName %>:<< pipeline.git.branch >>-sentry"
+            IMAGE="$DOCKER_REGISTRY/<%= projectName %>/<%= packageName %>/sentry:<< pipeline.git.branch >>"
             ENV="--env SENTRY_AUTH_TOKEN --env SENTRY_ORG --env SENTRY_PROJECT=<%= projectName %>-<%= packageName %>"
             VERSION=<%= projectName %>-<%= packageName %>@$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")
 

--- a/generators/react/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
+++ b/generators/react/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
@@ -1,5 +1,5 @@
 {{- define "<%= projectName %>.<%= packageName %>.image" }}
-{{- .Values.registry }}/<%= projectName %>-<%= packageName %>
+{{- .Values.registry }}/<%= projectName %>/<%= packageName %>
 {{- if .Values.<%= varName(packageName) %>.image.digest -}}
 @{{ .Values.<%= varName(packageName) %>.image.digest }}
 {{- else -}}

--- a/generators/symfony/index.ts
+++ b/generators/symfony/index.ts
@@ -101,14 +101,14 @@ class SymfonyGenerator extends PackageGenerator {
                 this.appendDestination('modules/deployment/release.tf', indent`
 
                     data "docker_registry_image" "${packageVar}_nginx" {
-                        name = "\${var.registry}/${projectName}-${packageName}-nginx:\${var.${packageVar}_image_tag}"
+                        name = "\${var.registry}/${projectName}/${packageName}/nginx:\${var.${packageVar}_image_tag}"
                     }
                 `);
 
                 this.appendDestination('modules/deployment/release.tf', indent`
 
                     data "docker_registry_image" "${packageVar}_php" {
-                        name = "\${var.registry}/${projectName}-${packageName}-php:\${var.${packageVar}_image_tag}"
+                        name = "\${var.registry}/${projectName}/${packageName}/php:\${var.${packageVar}_image_tag}"
                     }
                 `);
 

--- a/generators/symfony/templates/circleci.yaml.ejs
+++ b/generators/symfony/templates/circleci.yaml.ejs
@@ -214,12 +214,12 @@ jobs:
           version: 20.10.11
       - checkout
       - docker/build:
-          image: <%= projectName %>-<%= packageName %>-php
+          image: <%= projectName %>/<%= packageName %>/php
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--target=php --build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
       - docker/build:
-          image: <%= projectName %>-<%= packageName %>-nginx
+          image: <%= projectName %>/<%= packageName %>/nginx
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--target=nginx --build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
@@ -231,14 +231,14 @@ jobs:
       - checkout
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>-php
+          image: <%= projectName %>/<%= packageName %>/php
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
           extra_build_args: '--target=php --build-arg VERSION=$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")'
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>-nginx
+          image: <%= projectName %>/<%= packageName %>/nginx
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
@@ -246,7 +246,7 @@ jobs:
       <% if (twig) { %>
       - docker/build:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>-sentry
+          image: <%= projectName %>/<%= packageName %>/sentry
           tag: << pipeline.git.branch >>
           path: <%= packagePath %>
           docker-context: <%= packagePath %>
@@ -256,17 +256,17 @@ jobs:
           registry: $DOCKER_REGISTRY
       - docker/push:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>-php
+          image: <%= projectName %>/<%= packageName %>/php
           tag: << pipeline.git.branch >>
       - docker/push:
           registry: $DOCKER_REGISTRY
-          image: <%= projectName %>-<%= packageName %>-nginx
+          image: <%= projectName %>/<%= packageName %>/nginx
           tag: << pipeline.git.branch >>
       <% if (twig) { %>
       - run:
           name: Publish source maps to sentry
           command: |
-            IMAGE="$DOCKER_REGISTRY/<%= projectName %>-<%= packageName %>-sentry:<< pipeline.git.branch >>"
+            IMAGE="$DOCKER_REGISTRY/<%= projectName %>/<%= packageName %>/sentry:<< pipeline.git.branch >>"
             ENV="--env SENTRY_AUTH_TOKEN --env SENTRY_ORG --env SENTRY_PROJECT=<%= projectName %>-<%= packageName %>"
             VERSION=<%= projectName %>-<%= packageName %>@$(git log --max-count 1 --pretty=format:%H "<%= packagePath %>")
 

--- a/generators/symfony/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
+++ b/generators/symfony/templates/deployment/kubernetes/chart/_helpers.tpl.ejs
@@ -1,5 +1,5 @@
 {{- define "<%= projectName %>.<%= packageName %>.image.php" }}
-{{- .Values.registry }}/<%= projectName %>-<%= packageName %>-php
+{{- .Values.registry }}/<%= projectName %>/<%= packageName %>/php
 {{- if .Values.<%= varName(packageName) %>.image.digests.php -}}
 @{{ .Values.<%= varName(packageName) %>.image.digests.php }}
 {{- else -}}
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{- define "<%= projectName %>.<%= packageName %>.image.nginx" }}
-{{- .Values.registry }}/<%= projectName %>-<%= packageName %>-nginx
+{{- .Values.registry }}/<%= projectName %>/<%= packageName %>/nginx
 {{- if .Values.<%= varName(packageName) %>.image.digests.nginx -}}
 @{{ .Values.<%= varName(packageName) %>.image.digests.nginx }}
 {{- else -}}


### PR DESCRIPTION
The current code works but if you replace the CI with the GitHub action draft that is in https://github.com/thetribeio/generator-project/pull/1702 the images names built by CI use slashes instead of dashes, the PR normalize image names to always use slashes.