### PR TITLE
Update EJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "binascii": "^0.0.2",
     "crypto-random-string": "^3.3.1",
-    "ejs": "^3.1.9",
+    "ejs": "^3.1.10",
     "indent-tag": "^0.4.0",
     "ramda": "^0.30.1",
     "tslib": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,7 +1693,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^5.62.0"
     binascii: "npm:^0.0.2"
     crypto-random-string: "npm:^3.3.1"
-    ejs: "npm:^3.1.9"
+    ejs: "npm:^3.1.10"
     eslint: "npm:^8.37.0"
     eslint-plugin-import: "npm:^2.27.5"
     execa: "npm:^5.1.1"
@@ -3420,25 +3420,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^3.1.5":
-  version: 3.1.8
-  resolution: "ejs@npm:3.1.8"
+"ejs@npm:^3.1.10, ejs@npm:^3.1.5":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
   dependencies:
     jake: "npm:^10.8.5"
   bin:
     ejs: bin/cli.js
-  checksum: 10/879f84c8ee56d06dea7b47a8b493e1b398dba578ec7a701660cf77c8a6d565b932c5896639d1dc4a3be29204eccdb70ee4e1bdf634647c2490227f727d5d6a3d
-  languageName: node
-  linkType: hard
-
-"ejs@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "ejs@npm:3.1.9"
-  dependencies:
-    jake: "npm:^10.8.5"
-  bin:
-    ejs: bin/cli.js
-  checksum: 10/71f56d37540d2c2d71701f0116710c676f75314a3e997ef8b83515d5d4d2b111c5a72725377caeecb928671bacb84a0d38135f345904812e989847057d59f21a
+  checksum: 10/a9cb7d7cd13b7b1cd0be5c4788e44dd10d92f7285d2f65b942f33e127230c054f99a42db4d99f766d8dbc6c57e94799593ee66a14efd7c8dd70c4812bf6aa384
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace the [renovate PR](https://github.com/thetribeio/generator-project/pull/1733) to ensure the same version of EJS is used when imported directly and when used with yeoman.