### PR TITLE
Add packageManger key to all package.json

### DIFF
--- a/generators/express/templates/base/package.json
+++ b/generators/express/templates/base/package.json
@@ -1,5 +1,6 @@
 {
   "name": "name",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@sentry/node": "^7.13.0",
     "bcrypt": "^5.0.1",

--- a/generators/next-js/templates/base/package.json
+++ b/generators/next-js/templates/base/package.json
@@ -2,6 +2,7 @@
   "name": "name",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "next": "14.2.3",
     "react": "^18",

--- a/generators/react-admin/templates/base/package.json
+++ b/generators/react-admin/templates/base/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@sentry/browser": "^7.13.0",
     "ra-data-simple-rest": "^4.3.3",

--- a/generators/react-native-mobile/templates/base/package.json
+++ b/generators/react-native-mobile/templates/base/package.json
@@ -2,13 +2,7 @@
   "name": "name",
   "version": "0.0.1",
   "private": true,
-  "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
-    "start": "react-native start",
-    "test": "jest",
-    "lint": "eslint ."
-  },
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "react": "17.0.2",
     "react-native": "0.69.5"
@@ -22,6 +16,13 @@
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-test-renderer": "17.0.2"
+  },
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start",
+    "test": "jest",
+    "lint": "eslint ."
   },
   "jest": {
     "preset": "react-native"

--- a/generators/react/templates/base/package.json
+++ b/generators/react/templates/base/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@sentry/browser": "^7.13.0",
     "react": "^18.2.0",

--- a/generators/symfony/templates/base-twig/package.json
+++ b/generators/symfony/templates/base-twig/package.json
@@ -1,5 +1,6 @@
 {
   "name": "name",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@popperjs/core": "^2.11.7",
     "bootstrap": "^5.2.3"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "node": ">=18"
   },
+  "packageManager": "yarn@4.3.1",
   "dependencies": {
     "binascii": "^0.0.2",
     "crypto-random-string": "^3.3.1",
@@ -48,6 +49,5 @@
     "test:generators": "jest --runInBand --testTimeout 300000 generators",
     "test:utils": "jest --testTimeout 10000 utils",
     "test:utils:coverage": "yarn test:utils --coverage --collectCoverageFrom 'utils/**/*'"
-  },
-  "packageManager": "yarn@4.3.1"
+  }
 }


### PR DESCRIPTION
This should fix the Renovate fails. (It currently is bugged because of the mix of v1 and v4 in the repository)