### PR TITLE
Add yarnrc files to all templates

### DIFF
--- a/generators/express/templates/base/.yarnrc.yml
+++ b/generators/express/templates/base/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false

--- a/generators/next-js/templates/base/.yarnrc.yml
+++ b/generators/next-js/templates/base/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false

--- a/generators/react-admin/templates/base/.yarnrc.yml
+++ b/generators/react-admin/templates/base/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false

--- a/generators/react-native-mobile/templates/base/.yarnrc.yml
+++ b/generators/react-native-mobile/templates/base/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false

--- a/generators/react/templates/base/.yarnrc.yml
+++ b/generators/react/templates/base/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false

--- a/generators/symfony/templates/base-twig/.yarnrc.yml
+++ b/generators/symfony/templates/base-twig/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: false


### PR DESCRIPTION
This should prevent yarn from using the root yarn version because of config merging with parent folders.