### PR TITLE
Ensure template dependencies are not commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /coverage/
 /dist/
+/generators/*/templates/*/node_modules/
+/generators/*/templates/*/vendor/
 /node_modules/
 
 # Yarn


### PR DESCRIPTION
Some templates don't have a .gitignore file because they extends a template that already have one so this adds them to the root .gitignore to ensure they are never commited.