### PR TITLE
fix(start) Vite base apps use root instead of app

### DIFF
--- a/generators/react/templates/deployment/kubernetes/docker/start.sh.ejs
+++ b/generators/react/templates/deployment/kubernetes/docker/start.sh.ejs
@@ -4,7 +4,7 @@ set -e
 
 sed \
     --in-place \
-    --expression "s#<div id=\"app\"[^>]*>#<div id=\"app\" data-environment-name=\"$ENVIRONMENT_NAME\" data-sentry-dsn=\"$SENTRY_DSN\">#g" \
+    --expression "s#<div id=\"root\"[^>]*>#<div id=\"root\" data-environment-name=\"$ENVIRONMENT_NAME\" data-sentry-dsn=\"$SENTRY_DSN\">#g" \
     /srv/<%= packageName %>/index.html
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
CF this [slack thread](https://thetribeio.slack.com/archives/C76LURXR7/p1739964851482439).

Vite app use root as their base, so to properly inject the env vars into the root dataSet, we need a good target.