### PR TITLE
Disable fail fast on matrix jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
 
   test-utils:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18.20.4, 20.18.0, 22.11.0]
     runs-on: ubuntu-22.04
@@ -49,6 +50,7 @@ jobs:
 
   test-generators:
     strategy:
+      fail-fast: false
       matrix:
         shard: [1/3, 2/3, 3/3]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Matrix jobs, especialy generator tests can fail for random (most often network related) reasons. Not canceling jobs means we only have to rerun the job that failed instead of the whole matrix.